### PR TITLE
Add E2E tests and raise backend coverage to 82%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
         run: |
           cd backend
-          pytest -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=75
+          pytest -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=80
       - name: Optional Reality Defender live smoke (non-blocking)
         continue-on-error: true
         env:
@@ -90,6 +90,47 @@ jobs:
           npm run typecheck
           npm test
           npm run build
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: [backend-test, frontend-build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install backend
+        run: |
+          cd backend
+          pip install -e ".[dev]"
+      - name: Install frontend
+        run: |
+          cd frontend
+          npm ci
+      - name: Install Playwright browsers
+        run: |
+          cd frontend
+          npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        env:
+          CI: "true"
+          BASE_URL: http://localhost:3000
+          API_URL: http://localhost:8000
+        run: |
+          cd frontend
+          npx playwright test --reporter=github
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/test-results/
+          retention-days: 7
 
   public-benchmark:
     runs-on: ubuntu-latest

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -109,4 +109,4 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
-addopts = "-v --cov=app --cov-report=term-missing --cov-fail-under=75"
+addopts = "-v --cov=app --cov-report=term-missing --cov-fail-under=80"

--- a/backend/tests/test_c2pa_verifier_extended.py
+++ b/backend/tests/test_c2pa_verifier_extended.py
@@ -1,0 +1,182 @@
+"""Extended C2PA verifier tests covering parse/signature/assertion branches."""
+
+from __future__ import annotations
+
+from app.services.c2pa_verifier import C2PAVerifier
+
+
+def _verifier() -> C2PAVerifier:
+    return C2PAVerifier()
+
+
+# --- _parse_json_output --------------------------------------------------
+
+
+class TestParseJsonOutput:
+    def test_valid_json_string(self) -> None:
+        v = _verifier()
+        assert v._parse_json_output('{"status": "ok"}') == {"status": "ok"}
+
+    def test_empty_string_returns_none(self) -> None:
+        v = _verifier()
+        assert v._parse_json_output("") is None
+
+    def test_none_returns_none(self) -> None:
+        v = _verifier()
+        assert v._parse_json_output(None) is None
+
+    def test_non_dict_json_returns_none(self) -> None:
+        v = _verifier()
+        assert v._parse_json_output("[1, 2, 3]") is None
+
+    def test_json_with_leading_text(self) -> None:
+        v = _verifier()
+        result = v._parse_json_output('some noise {"key": "val"} trailing')
+        assert result == {"key": "val"}
+
+    def test_completely_invalid_json_returns_none(self) -> None:
+        v = _verifier()
+        assert v._parse_json_output("not json at all") is None
+
+
+# --- _infer_signature_valid -----------------------------------------------
+
+
+class TestInferSignatureValid:
+    def test_bool_flag_true(self) -> None:
+        v = _verifier()
+        payload = {"validation_results": {"active_manifest": {"valid": True}}}
+        assert v._infer_signature_valid(payload) is True
+
+    def test_bool_flag_false(self) -> None:
+        v = _verifier()
+        payload = {"validation_results": {"active_manifest": {"valid": False}}}
+        assert v._infer_signature_valid(payload) is False
+
+    def test_status_string_valid(self) -> None:
+        v = _verifier()
+        payload = {"validation_results": {"active_manifest": {"status": "verified"}}}
+        assert v._infer_signature_valid(payload) is True
+
+    def test_status_string_invalid(self) -> None:
+        v = _verifier()
+        payload = {"validation_results": {"active_manifest": {"status": "failed"}}}
+        assert v._infer_signature_valid(payload) is False
+
+    def test_no_validation_info(self) -> None:
+        v = _verifier()
+        assert v._infer_signature_valid({}) is False
+
+
+# --- _extract_assertions --------------------------------------------------
+
+
+class TestExtractAssertions:
+    def test_assertions_list_of_strings(self) -> None:
+        v = _verifier()
+        payload = {"assertions": ["c2pa.actions", "c2pa.hash.data"]}
+        assert v._extract_assertions(payload) == ["c2pa.actions", "c2pa.hash.data"]
+
+    def test_assertions_list_of_dicts(self) -> None:
+        v = _verifier()
+        payload = {"assertions": [{"label": "c2pa.actions"}, {"name": "c2pa.hash"}]}
+        assert v._extract_assertions(payload) == ["c2pa.actions", "c2pa.hash"]
+
+    def test_assertions_not_list(self) -> None:
+        v = _verifier()
+        assert v._extract_assertions({"assertions": "not-a-list"}) == []
+
+    def test_assertions_mixed_entries(self) -> None:
+        v = _verifier()
+        payload = {"assertions": ["c2pa.actions", {"type": "sig"}, 42]}
+        assert v._extract_assertions(payload) == ["c2pa.actions", "sig"]
+
+    def test_assertions_nested_under_active_manifest(self) -> None:
+        v = _verifier()
+        payload = {"active_manifest": {"assertions": [{"label": "nested"}]}}
+        assert v._extract_assertions(payload) == ["nested"]
+
+
+# --- _parse_payload additional branches -----------------------------------
+
+
+class TestParsePayload:
+    def test_manifest_present_but_signature_invalid(self) -> None:
+        v = _verifier()
+        payload = {
+            "active_manifest": {"label": "urn:123", "claim_generator": "Issuer"},
+            "signature": {"valid": False},
+        }
+        result = v._parse_payload(payload)
+        assert result.status == "unverified"
+        assert result.manifest_present is True
+        assert result.signature_valid is False
+
+    def test_manifest_store_path(self) -> None:
+        v = _verifier()
+        payload = {
+            "manifest_store": {
+                "active_manifest": {
+                    "label": "urn:456",
+                    "claim_generator": "StoreIssuer",
+                    "validation": {"valid": True},
+                    "assertions": [{"label": "c2pa.hash.data"}],
+                }
+            }
+        }
+        result = v._parse_payload(payload)
+        assert result.status == "verified"
+        assert result.issuer == "StoreIssuer"
+        assert result.manifest_id == "urn:456"
+        assert "c2pa.hash.data" in result.assertions
+
+
+# --- verify_bytes empty payload -------------------------------------------
+
+
+def test_verify_bytes_empty_payload() -> None:
+    v = _verifier()
+    result = v.verify_bytes(b"")
+    assert result.status == "unsupported"
+    assert result.manifest_present is False
+
+
+# --- _run_c2pa_tool with mock subprocess ----------------------------------
+
+
+def test_run_c2pa_tool_all_commands_fail(monkeypatch) -> None:
+    import subprocess as sp
+
+    def mock_run(*_args, **_kwargs):
+        result = sp.CompletedProcess(args=[], returncode=1, stdout="", stderr="parse error")
+        return result
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+    v = _verifier()
+    payload, error = v._run_c2pa_tool("c2patool", __import__("pathlib").Path("/fake.jpg"))
+    assert payload is None
+    assert "c2patool command failed" in error
+
+
+def test_run_c2pa_tool_success_on_first_attempt(monkeypatch) -> None:
+    import subprocess as sp
+
+    def mock_run(*_args, **_kwargs):
+        return sp.CompletedProcess(args=[], returncode=0, stdout='{"status": "ok"}', stderr="")
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+    v = _verifier()
+    payload, error = v._run_c2pa_tool("c2patool", __import__("pathlib").Path("/fake.jpg"))
+    assert payload == {"status": "ok"}
+    assert error == ""
+
+
+def test_run_c2pa_tool_exception(monkeypatch) -> None:
+    def mock_run(*_args, **_kwargs):
+        raise OSError("command not found")
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+    v = _verifier()
+    payload, error = v._run_c2pa_tool("c2patool", __import__("pathlib").Path("/fake.jpg"))
+    assert payload is None
+    assert "CLI execution error" in error

--- a/backend/tests/test_evaluation_store_extended.py
+++ b/backend/tests/test_evaluation_store_extended.py
@@ -1,0 +1,181 @@
+"""Extended evaluation store tests for uncovered branches."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from app.services.evaluation_store import EvaluationStore
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> EvaluationStore:
+    monkeypatch.setattr(
+        "app.services.evaluation_store.settings",
+        type("S", (), {"calibration_reports_dir": str(tmp_path)})(),
+    )
+    return EvaluationStore()
+
+
+def _write_report(base: Path, name: str, payload: dict) -> None:
+    path = base / name
+    path.write_text(json.dumps(payload, default=str), encoding="utf-8")
+
+
+class TestEvaluationStoreSummary:
+    def test_empty_directory(self, store: EvaluationStore) -> None:
+        result = store.get_summary(days=30)
+        assert result["total_reports"] == 0
+        assert result["trend"] == []
+
+    def test_report_outside_window(self, store: EvaluationStore, tmp_path: Path) -> None:
+        old_date = (datetime.now(UTC) - timedelta(days=200)).isoformat()
+        _write_report(
+            tmp_path,
+            "old.json",
+            {
+                "generated_at": old_date,
+                "content_type": "text",
+                "sample_count": 10,
+                "recommended_threshold": 0.5,
+                "best_metrics": {"precision": 0.9, "recall": 0.8, "f1": 0.85, "accuracy": 0.88},
+            },
+        )
+        result = store.get_summary(days=30)
+        assert result["total_reports"] == 0
+
+    def test_report_within_window(self, store: EvaluationStore, tmp_path: Path) -> None:
+        recent_date = datetime.now(UTC).isoformat()
+        _write_report(
+            tmp_path,
+            "recent.json",
+            {
+                "generated_at": recent_date,
+                "content_type": "text",
+                "sample_count": 50,
+                "recommended_threshold": 0.55,
+                "best_metrics": {"precision": 0.9, "recall": 0.85, "f1": 0.87, "accuracy": 0.9},
+            },
+        )
+        result = store.get_summary(days=90)
+        assert result["total_reports"] == 1
+        assert result["by_content_type"]["text"] == 1
+        assert result["latest_by_content_type"]["text"]["f1"] == 0.87
+
+    def test_invalid_json_is_skipped(self, store: EvaluationStore, tmp_path: Path) -> None:
+        (tmp_path / "broken.json").write_text("not json!", encoding="utf-8")
+        result = store.get_summary()
+        assert result["total_reports"] == 0
+
+    def test_missing_generated_at_is_skipped(self, store: EvaluationStore, tmp_path: Path) -> None:
+        _write_report(tmp_path, "no_date.json", {"content_type": "text"})
+        result = store.get_summary()
+        assert result["total_reports"] == 0
+
+    def test_non_string_generated_at_is_skipped(
+        self, store: EvaluationStore, tmp_path: Path
+    ) -> None:
+        _write_report(tmp_path, "bad_date.json", {"generated_at": 12345, "content_type": "text"})
+        result = store.get_summary()
+        assert result["total_reports"] == 0
+
+    def test_invalid_date_format_is_skipped(self, store: EvaluationStore, tmp_path: Path) -> None:
+        _write_report(
+            tmp_path, "bad_format.json", {"generated_at": "not-a-date", "content_type": "text"}
+        )
+        result = store.get_summary()
+        assert result["total_reports"] == 0
+
+    def test_naive_datetime_gets_utc_timezone(self, store: EvaluationStore, tmp_path: Path) -> None:
+        naive_date = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        _write_report(
+            tmp_path,
+            "naive.json",
+            {
+                "generated_at": naive_date,
+                "content_type": "image",
+                "sample_count": 20,
+                "recommended_threshold": 0.6,
+                "best_metrics": {"precision": 0.8, "recall": 0.7, "f1": 0.75, "accuracy": 0.78},
+            },
+        )
+        result = store.get_summary(days=7)
+        assert result["total_reports"] == 1
+
+    def test_f1_regression_alert(self, store: EvaluationStore, tmp_path: Path) -> None:
+        now = datetime.now(UTC)
+        _write_report(
+            tmp_path,
+            "report_01.json",
+            {
+                "generated_at": (now - timedelta(days=2)).isoformat(),
+                "content_type": "text",
+                "sample_count": 50,
+                "recommended_threshold": 0.5,
+                "best_metrics": {"precision": 0.9, "recall": 0.9, "f1": 0.9, "accuracy": 0.9},
+            },
+        )
+        _write_report(
+            tmp_path,
+            "report_02.json",
+            {
+                "generated_at": now.isoformat(),
+                "content_type": "text",
+                "sample_count": 50,
+                "recommended_threshold": 0.5,
+                "best_metrics": {"precision": 0.7, "recall": 0.7, "f1": 0.7, "accuracy": 0.7},
+            },
+        )
+        result = store.get_summary(days=30)
+        assert result["total_reports"] == 2
+        assert len(result["alerts"]) == 1
+        assert result["alerts"][0]["code"] == "f1_regression"
+
+    def test_no_regression_alert_when_f1_stable(
+        self, store: EvaluationStore, tmp_path: Path
+    ) -> None:
+        now = datetime.now(UTC)
+        _write_report(
+            tmp_path,
+            "stable_01.json",
+            {
+                "generated_at": (now - timedelta(days=1)).isoformat(),
+                "content_type": "text",
+                "sample_count": 50,
+                "recommended_threshold": 0.5,
+                "best_metrics": {"precision": 0.85, "recall": 0.85, "f1": 0.85, "accuracy": 0.85},
+            },
+        )
+        _write_report(
+            tmp_path,
+            "stable_02.json",
+            {
+                "generated_at": now.isoformat(),
+                "content_type": "text",
+                "sample_count": 50,
+                "recommended_threshold": 0.5,
+                "best_metrics": {"precision": 0.84, "recall": 0.84, "f1": 0.84, "accuracy": 0.84},
+            },
+        )
+        result = store.get_summary(days=30)
+        assert result["alerts"] == []
+
+    def test_days_clamp_min(self, store: EvaluationStore) -> None:
+        result = store.get_summary(days=-5)
+        assert result["window_days"] == 1
+
+    def test_days_clamp_max(self, store: EvaluationStore) -> None:
+        result = store.get_summary(days=9999)
+        assert result["window_days"] == 365
+
+    def test_nonexistent_reports_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.services.evaluation_store.settings",
+            type("S", (), {"calibration_reports_dir": "/tmp/does_not_exist_xyzzy"})(),
+        )
+        s = EvaluationStore()
+        result = s.get_summary()
+        assert result["total_reports"] == 0

--- a/backend/tests/test_scheduler_helpers.py
+++ b/backend/tests/test_scheduler_helpers.py
@@ -1,0 +1,146 @@
+"""Tests for job scheduler helper functions and budget tracking."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.services.job_scheduler import _slug_handle, XPipelineScheduler
+
+
+class TestSlugHandle:
+    def test_strips_at_sign(self) -> None:
+        assert _slug_handle("@user_name") == "user_name"
+
+    def test_lowercases(self) -> None:
+        assert _slug_handle("UserName") == "username"
+
+    def test_replaces_special_chars_with_hyphen(self) -> None:
+        assert _slug_handle("user.name!") == "user-name"
+
+    def test_strips_leading_trailing_hyphens(self) -> None:
+        assert _slug_handle("@---user---") == "user"
+
+    def test_empty_returns_target(self) -> None:
+        assert _slug_handle("") == "target"
+
+    def test_whitespace_only_returns_target(self) -> None:
+        assert _slug_handle("   ") == "target"
+
+
+class TestUsageStatePersistence:
+    def test_load_usage_state_missing_file(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "app.services.job_scheduler.settings",
+            type(
+                "S",
+                (),
+                {
+                    "scheduler_usage_file": str(tmp_path / "nonexistent.json"),
+                    "scheduler_enabled": False,
+                    "scheduler_handles": [],
+                    "scheduler_monthly_request_cap": 0,
+                    "scheduler_interval_minutes": 60,
+                },
+            )(),
+        )
+        scheduler = XPipelineScheduler()
+        assert scheduler._usage_state == {"months": {}}
+
+    def test_load_usage_state_corrupt_file(self, tmp_path: Path, monkeypatch) -> None:
+        usage_file = tmp_path / "usage.json"
+        usage_file.write_text("not json", encoding="utf-8")
+        monkeypatch.setattr(
+            "app.services.job_scheduler.settings",
+            type(
+                "S",
+                (),
+                {
+                    "scheduler_usage_file": str(usage_file),
+                    "scheduler_enabled": False,
+                    "scheduler_handles": [],
+                    "scheduler_monthly_request_cap": 0,
+                    "scheduler_interval_minutes": 60,
+                },
+            )(),
+        )
+        scheduler = XPipelineScheduler()
+        assert scheduler._usage_state == {"months": {}}
+
+    def test_save_and_reload_usage(self, tmp_path: Path, monkeypatch) -> None:
+        usage_file = tmp_path / "usage.json"
+        settings_mock = type(
+            "S",
+            (),
+            {
+                "scheduler_usage_file": str(usage_file),
+                "scheduler_enabled": False,
+                "scheduler_handles": [],
+                "scheduler_monthly_request_cap": 1000,
+                "scheduler_interval_minutes": 60,
+            },
+        )()
+        monkeypatch.setattr("app.services.job_scheduler.settings", settings_mock)
+        scheduler = XPipelineScheduler()
+        scheduler._record_consumed_requests(42)
+
+        assert usage_file.exists()
+        data = json.loads(usage_file.read_text(encoding="utf-8"))
+        month_key = scheduler._month_key()
+        assert data["months"][month_key]["requests_used"] == 42
+
+
+class TestMonthlyBudget:
+    def test_budget_no_cap(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "app.services.job_scheduler.settings",
+            type(
+                "S",
+                (),
+                {
+                    "scheduler_usage_file": str(tmp_path / "usage.json"),
+                    "scheduler_enabled": False,
+                    "scheduler_handles": [],
+                    "scheduler_monthly_request_cap": 0,
+                    "scheduler_interval_minutes": 60,
+                },
+            )(),
+        )
+        scheduler = XPipelineScheduler()
+        budget = scheduler._monthly_budget()
+        assert budget["cap_requests"] == 0
+        assert budget["remaining_requests"] is None
+
+    def test_budget_with_cap(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "app.services.job_scheduler.settings",
+            type(
+                "S",
+                (),
+                {
+                    "scheduler_usage_file": str(tmp_path / "usage.json"),
+                    "scheduler_enabled": False,
+                    "scheduler_handles": [],
+                    "scheduler_monthly_request_cap": 100,
+                    "scheduler_interval_minutes": 60,
+                },
+            )(),
+        )
+        scheduler = XPipelineScheduler()
+        budget = scheduler._monthly_budget()
+        assert budget["cap_requests"] == 100
+        assert budget["remaining_requests"] == 100
+
+
+class TestMonthKey:
+    def test_format(self) -> None:
+        now = datetime(2026, 2, 15, tzinfo=UTC)
+        assert XPipelineScheduler._month_key(now) == "2026-02"
+
+    def test_defaults_to_now(self) -> None:
+        key = XPipelineScheduler._month_key()
+        assert len(key) == 7
+        assert key[4] == "-"

--- a/backend/tests/test_schema_constants.py
+++ b/backend/tests/test_schema_constants.py
@@ -1,0 +1,14 @@
+"""Tests for schema constants (image limits)."""
+
+from app.schemas.image import ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE_BYTES
+
+
+def test_allowed_image_types_contains_expected() -> None:
+    assert "image/jpeg" in ALLOWED_IMAGE_TYPES
+    assert "image/png" in ALLOWED_IMAGE_TYPES
+    assert "image/webp" in ALLOWED_IMAGE_TYPES
+    assert len(ALLOWED_IMAGE_TYPES) == 3
+
+
+def test_max_image_size_is_10mb() -> None:
+    assert MAX_IMAGE_SIZE_BYTES == 10 * 1024 * 1024

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -1,0 +1,90 @@
+"""Tests for worker entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.worker.main import main, run_worker
+
+
+@pytest.mark.asyncio
+async def test_run_worker_starts_and_stops() -> None:
+    """Worker should init DB, enter loop, and exit when cancelled."""
+    with (
+        patch("app.worker.main.init_database", new_callable=AsyncMock) as mock_init,
+        patch("app.worker.main.close_database", new_callable=AsyncMock),
+        patch("app.worker.main.x_pipeline_scheduler"),
+        patch("app.worker.main.webhook_dispatcher"),
+        patch("app.worker.main.settings") as mock_settings,
+    ):
+        mock_settings.worker_tick_seconds = 1
+        mock_settings.worker_enable_scheduler = False
+        mock_settings.worker_drain_webhook_queue = False
+
+        task = asyncio.create_task(run_worker())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        mock_init.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_worker_drains_webhook_queue() -> None:
+    """Worker should drain webhook queue when enabled."""
+    with (
+        patch("app.worker.main.init_database", new_callable=AsyncMock),
+        patch("app.worker.main.close_database", new_callable=AsyncMock),
+        patch("app.worker.main.x_pipeline_scheduler"),
+        patch("app.worker.main.webhook_dispatcher") as mock_dispatcher,
+        patch("app.worker.main.settings") as mock_settings,
+    ):
+        mock_settings.worker_tick_seconds = 1
+        mock_settings.worker_enable_scheduler = False
+        mock_settings.worker_drain_webhook_queue = True
+        mock_dispatcher.drain_retry_queue = AsyncMock(
+            return_value={"processed": 0, "dead_lettered": 0}
+        )
+
+        task = asyncio.create_task(run_worker())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        mock_dispatcher.drain_retry_queue.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_worker_starts_scheduler() -> None:
+    """Worker should start scheduler when enabled."""
+    with (
+        patch("app.worker.main.init_database", new_callable=AsyncMock),
+        patch("app.worker.main.close_database", new_callable=AsyncMock),
+        patch("app.worker.main.x_pipeline_scheduler") as mock_scheduler,
+        patch("app.worker.main.webhook_dispatcher"),
+        patch("app.worker.main.settings") as mock_settings,
+    ):
+        mock_settings.worker_tick_seconds = 1
+        mock_settings.worker_enable_scheduler = True
+        mock_settings.worker_drain_webhook_queue = False
+        mock_scheduler.start = AsyncMock()
+        mock_scheduler.stop = AsyncMock()
+
+        task = asyncio.create_task(run_worker())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        mock_scheduler.start.assert_awaited_once()
+
+
+def test_main_returns_zero_on_keyboard_interrupt() -> None:
+    """main() should catch KeyboardInterrupt and return 0."""
+    with patch("app.worker.main.asyncio.run", side_effect=KeyboardInterrupt):
+        assert main() == 0

--- a/frontend/e2e/history-dashboard.spec.ts
+++ b/frontend/e2e/history-dashboard.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("History Page", () => {
+  test("renders empty state when no analyses exist", async ({ page }) => {
+    await page.goto("/history");
+    // Either shows items or empty state
+    const heading = page.getByRole("heading", { name: "Analysis History" });
+    await expect(heading).toBeVisible();
+  });
+
+  test("has content type filter dropdown", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByLabel("Filter by content type")).toBeVisible();
+  });
+
+  test("has export buttons", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByRole("button", { name: "CSV" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "JSON" })).toBeVisible();
+  });
+
+  test("links to dashboard from history page", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByText("View analytics dashboard")).toBeVisible();
+  });
+});
+
+test.describe("Dashboard Page", () => {
+  test("renders dashboard heading and window selector", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: /Dashboard/i })
+    ).toBeVisible();
+    await expect(page.getByLabel("Window")).toBeVisible();
+  });
+
+  test("has export buttons", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByRole("button", { name: "CSV" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "JSON" }).first()).toBeVisible();
+  });
+
+  test("shows loading then content", async ({ page }) => {
+    await page.goto("/dashboard");
+    // Should show loading or content
+    const hasLoading = await page.getByText("Loading dashboard...").isVisible().catch(() => false);
+    if (hasLoading) {
+      // Wait for loading to finish
+      await expect(page.getByText("Loading dashboard...")).toBeHidden({ timeout: 15000 });
+    }
+    // Dashboard should show stats or error
+    const hasStats = await page.getByText("Window Analyses").isVisible().catch(() => false);
+    const hasError = await page.locator("[role='alert']").isVisible().catch(() => false);
+    expect(hasStats || hasError).toBeTruthy();
+  });
+
+  test("can change window period", async ({ page }) => {
+    await page.goto("/dashboard");
+    const select = page.getByLabel("Window");
+    await select.selectOption("30");
+    // Should trigger reload
+    await expect(select).toHaveValue("30");
+  });
+});

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Navigation", () => {
+  test("homepage loads with brand and navigation", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/AI Provenance/i);
+    await expect(page.getByRole("link", { name: /AI Provenance/i }).first()).toBeVisible();
+  });
+
+  test("navigates to text detection page", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "Text" }).first().click();
+    await expect(page).toHaveURL("/detect/text");
+    await expect(page.getByRole("heading", { name: "Text Detection" })).toBeVisible();
+  });
+
+  test("navigates to image detection page", async ({ page }) => {
+    await page.goto("/detect/image");
+    await expect(page.getByRole("heading", { name: "Image Detection" })).toBeVisible();
+  });
+
+  test("navigates to dashboard page", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: /Dashboard/i })).toBeVisible();
+  });
+
+  test("navigates to history page", async ({ page }) => {
+    await page.goto("/history");
+    await expect(page.getByRole("heading", { name: "Analysis History" })).toBeVisible();
+  });
+
+  test("header has mobile menu toggle", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+    await expect(page.getByLabel("Toggle menu")).toBeVisible();
+  });
+
+  test("footer renders detection links", async ({ page }) => {
+    await page.goto("/");
+    const footer = page.locator("footer");
+    await expect(footer.getByText("Text Detection")).toBeVisible();
+    await expect(footer.getByText("Image Detection")).toBeVisible();
+  });
+});

--- a/frontend/e2e/text-detection.spec.ts
+++ b/frontend/e2e/text-detection.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Text Detection Flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/detect/text");
+  });
+
+  test("page renders input area and analyze button", async ({ page }) => {
+    await expect(page.getByLabel("Text to analyze for AI detection")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Analyze Text" })).toBeVisible();
+  });
+
+  test("analyze button is disabled when text is too short", async ({ page }) => {
+    const button = page.getByRole("button", { name: "Analyze Text" });
+    await expect(button).toBeDisabled();
+  });
+
+  test("can type text and enable analyze button", async ({ page }) => {
+    const textarea = page.getByLabel("Text to analyze for AI detection");
+    await textarea.fill("A".repeat(60));
+    const button = page.getByRole("button", { name: "Analyze Text" });
+    await expect(button).toBeEnabled();
+  });
+
+  test("Try Sample button fills textarea", async ({ page }) => {
+    await page.getByLabel("Load a sample AI-generated text").click();
+    const textarea = page.getByLabel("Text to analyze for AI detection");
+    const value = await textarea.inputValue();
+    expect(value.length).toBeGreaterThan(50);
+  });
+
+  test("full analysis flow with sample text", async ({ page }) => {
+    // Load sample text
+    await page.getByLabel("Load a sample AI-generated text").click();
+
+    // Click analyze
+    await page.getByRole("button", { name: "Analyze Text" }).click();
+
+    // Wait for analysis to complete (loading state appears then result)
+    await expect(page.getByText("Analyzing content...")).toBeVisible({ timeout: 5000 });
+
+    // Wait for result to appear
+    await expect(page.getByText("Detection Signals")).toBeVisible({ timeout: 30000 });
+
+    // Verify result card elements
+    await expect(page.getByText("AI Confidence")).toBeVisible();
+
+    // Verify "Analyze another text" button appears
+    await expect(page.getByText("Analyze another text")).toBeVisible();
+  });
+
+  test("shows character count", async ({ page }) => {
+    await expect(page.getByText("0 / 50,000")).toBeVisible();
+    const textarea = page.getByLabel("Text to analyze for AI detection");
+    await textarea.fill("Hello world");
+    await expect(page.getByText("11 / 50,000")).toBeVisible();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^16.1.6",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1980,6 +1981,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7220,6 +7237,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "analyze": "ANALYZE=true next build"
+    "analyze": "ANALYZE=true next build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.1.6",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+const API_URL = process.env.API_URL || "http://localhost:8000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: process.env.CI
+        ? `cd ../backend && uvicorn app.main:app --host 127.0.0.1 --port 8000`
+        : `cd ../backend && .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8000`,
+      url: `${API_URL}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: "npm run dev -- --port 3000",
+      url: BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests covering navigation, text detection flow, and history/dashboard pages (21 specs)
- Add 54 new backend unit tests for C2PA verifier, evaluation store, worker entrypoint, scheduler helpers, and schema constants
- Raise backend coverage threshold from 75% to 80% (actual: 81.78%, 222 total tests)
- Add E2E CI job that runs Playwright after unit tests pass

## Test plan
- [ ] `cd backend && pytest` — 222 tests pass, 81.78% coverage
- [ ] `cd frontend && npm test` — 66 tests pass
- [ ] `cd frontend && npx playwright test` — 21 E2E specs pass (requires backend + frontend running)
- [ ] CI pipeline completes with new E2E job