### PR TITLE
Add backend service tests and media detection E2E coverage

### DIFF
--- a/backend/tests/test_analysis_store.py
+++ b/backend/tests/test_analysis_store.py
@@ -1,0 +1,255 @@
+"""Tests for the AnalysisStore persistence layer."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from pydantic import BaseModel
+
+from app.services.analysis_store import AnalysisStore, analysis_store
+
+
+class FakeResult(BaseModel):
+    """Minimal pydantic model that acts like a detection result."""
+
+    is_ai_generated: bool = True
+    confidence: float = 0.85
+    model_prediction: str | None = "gpt-4"
+    explanation: str = "Test detection result."
+
+
+# ── save + get round-trip ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_save_text_result_returns_id() -> None:
+    aid = await analysis_store.save_text_result("hello world", FakeResult())
+    assert isinstance(aid, str) and len(aid) > 0
+
+
+@pytest.mark.asyncio
+async def test_save_text_result_and_get_record() -> None:
+    aid = await analysis_store.save_text_result("test text", FakeResult(confidence=0.9))
+    record = await analysis_store.get_record(aid)
+    assert record is not None
+    assert record.analysis_id == aid
+    assert record.content_type == "text"
+    assert record.result["confidence"] == 0.9
+    assert record.content_hash == hashlib.sha256(b"test text").hexdigest()
+    assert record.input_size == len("test text")
+
+
+@pytest.mark.asyncio
+async def test_save_image_result_stores_filename() -> None:
+    data = b"\x89PNG fake image bytes"
+    aid = await analysis_store.save_image_result(data, "test.png", FakeResult())
+    record = await analysis_store.get_record(aid)
+    assert record is not None
+    assert record.filename == "test.png"
+    assert record.content_type == "image"
+    assert record.input_size == len(data)
+
+
+@pytest.mark.asyncio
+async def test_save_audio_result_stores_hash() -> None:
+    data = b"RIFF fake audio bytes"
+    aid = await analysis_store.save_audio_result(data, "test.wav", FakeResult())
+    record = await analysis_store.get_record(aid)
+    assert record is not None
+    assert record.content_hash == hashlib.sha256(data).hexdigest()
+    assert record.content_type == "audio"
+
+
+@pytest.mark.asyncio
+async def test_save_video_result_stores_size() -> None:
+    data = b"\x00\x00\x00\x1c ftypmp42"
+    aid = await analysis_store.save_video_result(data, "test.mp4", FakeResult())
+    record = await analysis_store.get_record(aid)
+    assert record is not None
+    assert record.input_size == len(data)
+    assert record.content_type == "video"
+
+
+@pytest.mark.asyncio
+async def test_get_record_returns_none_for_missing_id() -> None:
+    assert await analysis_store.get_record("nonexistent-id-000") is None
+
+
+# ── get_history ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_history_returns_reverse_chronological() -> None:
+    for i in range(3):
+        await analysis_store.save_text_result(f"text-{i}", FakeResult())
+    items, total = await analysis_store.get_history(limit=10, offset=0)
+    assert total == 3
+    assert len(items) == 3
+    # newest first: items[0].created_at > items[1].created_at
+    assert items[0]["created_at"] >= items[1]["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_get_history_filters_by_content_type() -> None:
+    await analysis_store.save_text_result("text", FakeResult())
+    await analysis_store.save_image_result(b"img", "img.png", FakeResult())
+    items, total = await analysis_store.get_history(limit=10, offset=0, content_type="text")
+    assert total == 1
+    assert items[0]["content_type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_get_history_pagination() -> None:
+    for i in range(5):
+        await analysis_store.save_text_result(f"text-{i}", FakeResult())
+    items, total = await analysis_store.get_history(limit=2, offset=0)
+    assert total == 5
+    assert len(items) == 2
+    items2, _ = await analysis_store.get_history(limit=2, offset=2)
+    assert len(items2) == 2
+    # No overlap
+    ids_page1 = {it["analysis_id"] for it in items}
+    ids_page2 = {it["analysis_id"] for it in items2}
+    assert ids_page1.isdisjoint(ids_page2)
+
+
+# ── get_stats ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_stats_empty_store() -> None:
+    stats = await analysis_store.get_stats()
+    assert stats["total_analyses"] == 0
+    assert stats["average_confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_stats_with_mixed_records() -> None:
+    await analysis_store.save_text_result(
+        "ai text", FakeResult(is_ai_generated=True, confidence=0.9)
+    )
+    await analysis_store.save_text_result(
+        "human text", FakeResult(is_ai_generated=False, confidence=0.1)
+    )
+    await analysis_store.save_image_result(
+        b"img", "img.png", FakeResult(is_ai_generated=True, confidence=0.8)
+    )
+
+    stats = await analysis_store.get_stats()
+    assert stats["total_analyses"] == 3
+    assert stats["ai_detected_count"] == 2
+    assert stats["human_detected_count"] == 1
+    assert stats["by_type"]["text"] == 2
+    assert stats["by_type"]["image"] == 1
+    assert stats["average_confidence"] == pytest.approx(0.6, abs=0.01)
+
+
+# ── get_dashboard ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_empty() -> None:
+    dashboard = await analysis_store.get_dashboard(days=7)
+    assert dashboard["window_days"] == 7
+    assert dashboard["summary"]["total_analyses_window"] == 0
+    assert len(dashboard["timeline"]) == 7
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_with_records() -> None:
+    for _ in range(3):
+        await analysis_store.save_text_result("t", FakeResult(is_ai_generated=True, confidence=0.8))
+    for _ in range(2):
+        await analysis_store.save_text_result(
+            "t", FakeResult(is_ai_generated=False, confidence=0.2)
+        )
+
+    dashboard = await analysis_store.get_dashboard(days=7)
+    summary = dashboard["summary"]
+    assert summary["total_analyses_all_time"] == 5
+    assert summary["total_analyses_window"] == 5
+    assert summary["ai_detected_window"] == 3
+    assert summary["human_detected_window"] == 2
+    assert summary["ai_rate_window"] == pytest.approx(0.6, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_top_models() -> None:
+    await analysis_store.save_text_result("t", FakeResult(model_prediction="gpt-4"))
+    await analysis_store.save_text_result("t", FakeResult(model_prediction="gpt-4"))
+    await analysis_store.save_text_result("t", FakeResult(model_prediction="claude-3"))
+
+    dashboard = await analysis_store.get_dashboard(days=7)
+    top_models = dashboard["top_models_window"]
+    assert len(top_models) >= 1
+    assert top_models[0]["model"] == "gpt-4"
+    assert top_models[0]["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_clamps_days() -> None:
+    dashboard = await analysis_store.get_dashboard(days=200)
+    assert dashboard["window_days"] == 90
+
+
+# ── reset ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_records() -> None:
+    await analysis_store.save_text_result("text", FakeResult())
+    stats_before = await analysis_store.get_stats()
+    assert stats_before["total_analyses"] == 1
+
+    await analysis_store.reset()
+    stats_after = await analysis_store.get_stats()
+    assert stats_after["total_analyses"] == 0
+
+
+# ── max_items eviction ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_items_eviction() -> None:
+    small_store = AnalysisStore(max_items=3)
+    small_store._initialized = True  # skip re-init since conftest already did it
+    ids = []
+    for i in range(5):
+        aid = await small_store.save_text_result(f"text-{i}", FakeResult())
+        ids.append(aid)
+
+    # oldest 2 should have been evicted
+    assert await small_store.get_record(ids[0]) is None
+    assert await small_store.get_record(ids[1]) is None
+    # newest 3 remain
+    assert await small_store.get_record(ids[2]) is not None
+    assert await small_store.get_record(ids[3]) is not None
+    assert await small_store.get_record(ids[4]) is not None
+
+
+# ── _to_history_item structure ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_history_item_structure() -> None:
+    aid = await analysis_store.save_text_result(
+        "test",
+        FakeResult(
+            is_ai_generated=True, confidence=0.85, model_prediction="gpt-4", explanation="Test."
+        ),
+        source="extension",
+        source_url="https://example.com",
+    )
+    items, _ = await analysis_store.get_history(limit=1, offset=0)
+    item = items[0]
+
+    assert item["analysis_id"] == aid
+    assert item["content_type"] == "text"
+    assert item["is_ai_generated"] is True
+    assert item["confidence"] == 0.85
+    assert item["model_prediction"] == "gpt-4"
+    assert item["explanation"] == "Test."
+    assert item["source"] == "extension"
+    assert item["source_url"] == "https://example.com"
+    assert "created_at" in item

--- a/backend/tests/test_audit_events.py
+++ b/backend/tests/test_audit_events.py
@@ -1,0 +1,166 @@
+"""Tests for the AuditEventStore persistence layer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.services.audit_events import AuditEventStore, audit_event_store
+
+
+# ── log_event ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_event_returns_id() -> None:
+    event_id = await audit_event_store.log_event(event_type="test_event")
+    assert isinstance(event_id, int)
+
+
+@pytest.mark.asyncio
+async def test_log_event_stores_all_fields() -> None:
+    event_id = await audit_event_store.log_event(
+        event_type="detection.completed",
+        severity="info",
+        source="api",
+        actor_id="user-123",
+        request_id="req-456",
+        payload={"analysis_id": "abc-789"},
+    )
+    items, total = await audit_event_store.list_events(limit=10, offset=0)
+    assert total == 1
+    item = items[0]
+    assert item["id"] == event_id
+    assert item["event_type"] == "detection.completed"
+    assert item["severity"] == "info"
+    assert item["source"] == "api"
+    assert item["actor_id"] == "user-123"
+    assert item["request_id"] == "req-456"
+    assert item["payload"] == {"analysis_id": "abc-789"}
+    assert "created_at" in item
+
+
+@pytest.mark.asyncio
+async def test_log_event_returns_none_when_disabled() -> None:
+    original = settings.audit_events_enabled
+    try:
+        settings.audit_events_enabled = False
+        result = await audit_event_store.log_event(event_type="should_be_skipped")
+        assert result is None
+    finally:
+        settings.audit_events_enabled = original
+
+
+@pytest.mark.asyncio
+async def test_log_event_with_default_values() -> None:
+    await audit_event_store.log_event(event_type="simple")
+    items, _ = await audit_event_store.list_events(limit=10, offset=0)
+    item = items[0]
+    assert item["severity"] == "info"
+    assert item["source"] == "api"
+    assert item["actor_id"] is None
+    assert item["request_id"] is None
+    assert item["payload"] == {}
+
+
+# ── safe_log_event ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_safe_log_event_does_not_raise_on_failure() -> None:
+    store = AuditEventStore()
+    with patch.object(
+        store, "log_event", new_callable=AsyncMock, side_effect=RuntimeError("db down")
+    ):
+        await store.safe_log_event(event_type="fail_event")
+        # no exception should propagate
+
+
+@pytest.mark.asyncio
+async def test_safe_log_event_logs_warning_on_failure() -> None:
+    store = AuditEventStore()
+    with (
+        patch.object(
+            store, "log_event", new_callable=AsyncMock, side_effect=RuntimeError("db down")
+        ),
+        patch("app.services.audit_events.logger") as mock_logger,
+    ):
+        await store.safe_log_event(event_type="fail_event")
+        mock_logger.warning.assert_called_once()
+
+
+# ── list_events ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_events_returns_paginated() -> None:
+    for i in range(5):
+        await audit_event_store.log_event(event_type=f"event-{i}")
+    items, total = await audit_event_store.list_events(limit=2, offset=0)
+    assert total == 5
+    assert len(items) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_events_filters_by_event_type() -> None:
+    await audit_event_store.log_event(event_type="detection.text")
+    await audit_event_store.log_event(event_type="detection.image")
+    await audit_event_store.log_event(event_type="detection.text")
+
+    items, total = await audit_event_store.list_events(
+        limit=10, offset=0, event_type="detection.text"
+    )
+    assert total == 2
+    assert all(item["event_type"] == "detection.text" for item in items)
+
+
+@pytest.mark.asyncio
+async def test_list_events_filters_by_severity() -> None:
+    await audit_event_store.log_event(event_type="a", severity="info")
+    await audit_event_store.log_event(event_type="b", severity="warning")
+    await audit_event_store.log_event(event_type="c", severity="info")
+
+    items, total = await audit_event_store.list_events(limit=10, offset=0, severity="warning")
+    assert total == 1
+    assert items[0]["event_type"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_list_events_combined_filters() -> None:
+    await audit_event_store.log_event(event_type="detection.text", severity="info")
+    await audit_event_store.log_event(event_type="detection.text", severity="warning")
+    await audit_event_store.log_event(event_type="detection.image", severity="warning")
+
+    items, total = await audit_event_store.list_events(
+        limit=10, offset=0, event_type="detection.text", severity="warning"
+    )
+    assert total == 1
+    assert items[0]["event_type"] == "detection.text"
+    assert items[0]["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_list_events_newest_first() -> None:
+    await audit_event_store.log_event(event_type="first")
+    await audit_event_store.log_event(event_type="second")
+    await audit_event_store.log_event(event_type="third")
+
+    items, _ = await audit_event_store.list_events(limit=10, offset=0)
+    assert items[0]["event_type"] == "third"
+    assert items[2]["event_type"] == "first"
+
+
+# ── reset ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_events() -> None:
+    await audit_event_store.log_event(event_type="to_be_cleared")
+    _, total_before = await audit_event_store.list_events(limit=1, offset=0)
+    assert total_before == 1
+
+    await audit_event_store.reset()
+    _, total_after = await audit_event_store.list_events(limit=1, offset=0)
+    assert total_after == 0

--- a/frontend/e2e/media-detection.spec.ts
+++ b/frontend/e2e/media-detection.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Image Detection Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/detect/image");
+  });
+
+  test("renders heading and description", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Image Detection" })
+    ).toBeVisible();
+    await expect(
+      page.getByText("Upload an image to analyze")
+    ).toBeVisible();
+  });
+
+  test("renders upload dropzone with format text", async ({ page }) => {
+    await expect(page.getByText(/Drag & drop an image/)).toBeVisible();
+    await expect(page.getByText(/Supports JPEG, PNG, WebP/)).toBeVisible();
+  });
+
+  test("file input has correct aria-label", async ({ page }) => {
+    await expect(
+      page.getByLabel("Upload image file for AI detection")
+    ).toBeAttached();
+  });
+
+  test("no analyze button visible without file", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "Analyze Image" })
+    ).not.toBeVisible();
+  });
+});
+
+test.describe("Audio Detection Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/detect/audio");
+  });
+
+  test("renders heading with Beta badge", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Audio Detection" })
+    ).toBeVisible();
+    await expect(page.getByText("Beta")).toBeVisible();
+  });
+
+  test("renders description", async ({ page }) => {
+    await expect(
+      page.getByText("Upload a WAV file to analyze")
+    ).toBeVisible();
+  });
+
+  test("renders upload dropzone for WAV files", async ({ page }) => {
+    await expect(page.getByText(/Drag & drop a WAV file/)).toBeVisible();
+    await expect(page.getByText(/Supports WAV/)).toBeVisible();
+  });
+
+  test("file input has correct aria-label", async ({ page }) => {
+    await expect(
+      page.getByLabel("Upload audio file for AI detection")
+    ).toBeAttached();
+  });
+});
+
+test.describe("Video Detection Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/detect/video");
+  });
+
+  test("renders heading with Beta badge", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Video Detection" })
+    ).toBeVisible();
+    await expect(page.getByText("Beta")).toBeVisible();
+  });
+
+  test("renders description", async ({ page }) => {
+    await expect(
+      page.getByText("Upload a short video clip to analyze")
+    ).toBeVisible();
+  });
+
+  test("renders upload dropzone for video files", async ({ page }) => {
+    await expect(page.getByText(/Drag & drop a video/)).toBeVisible();
+    await expect(
+      page.getByText(/Supports MP4, WebM, MOV, AVI, MKV/)
+    ).toBeVisible();
+  });
+
+  test("file input has correct aria-label", async ({ page }) => {
+    await expect(
+      page.getByLabel("Upload video file for AI detection")
+    ).toBeAttached();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 18 tests for `analysis_store` (save/get round-trip, history pagination, stats aggregation, dashboard alerts, max_items eviction, reset)
- Add 12 tests for `audit_events` (log/list with filters, safe_log_event failure handling, disabled state, reset)
- Add 12 E2E tests for image/audio/video detection pages (headings, dropzone rendering, aria-labels, beta badges)

## Test plan
- `analysis_store` coverage: 0% → 97%
- `audit_events` coverage: 0% → 94%
- Backend tests: 222 → 252, overall coverage: 83.98%
- E2E tests: 21 → 33, all 4 media types now have E2E coverage
- `cd backend && pytest -v --cov-fail-under=80` passes
- `cd frontend && npx playwright test` passes