### PR TITLE
chore: close remaining infra gaps and link operator docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,5 +63,8 @@ APT_WEBHOOK_RETRY_BACKOFF_SECONDS=2
 APT_WEBHOOK_QUEUE_FILE=evidence/webhooks/retry_queue.json
 APT_WEBHOOK_DEAD_LETTER_FILE=evidence/webhooks/dead_letter.jsonl
 
+# Observability
+APT_ENABLE_PROMETHEUS=true
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8010

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+<!-- 1-3 bullet points describing the change -->
+
+## Type of Change
+- [ ] Feature (new functionality)
+- [ ] Bug fix
+- [ ] Refactor (no behaviour change)
+- [ ] Documentation
+- [ ] Tests
+- [ ] Infrastructure / CI
+
+## Test Plan
+<!-- How was this tested? -->
+- [ ] Unit tests pass
+- [ ] E2E tests pass
+- [ ] Manual verification
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets or credentials committed

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ graph TB
 | **Cache** | Redis 7 | Response caching and job queue |
 | **Infrastructure** | Docker, Kubernetes (Helm), Terraform (AWS) | Multi-target deployment |
 | **Quality** | Ruff, MyPy, Pytest, pre-commit hooks | Code quality and type safety |
-| **Observability** | Structlog (structured logging) | Production monitoring |
+| **Observability** | Structlog, Prometheus (structured logging, metrics) | Production monitoring |
 
 ---
 
@@ -666,6 +666,9 @@ See:
 - `docs/COST_GOVERNANCE.md`
 - `docs/SLO_OBSERVABILITY.md`
 - `docs/SUPPLY_CHAIN_SECURITY.md`
+- `docs/TROUBLESHOOTING.md`
+- `docs/PERFORMANCE_TUNING.md`
+- `docs/DATA_RETENTION.md`
 
 ---
 

--- a/deploy/helm/provenance-stack/templates/api-deployment.yaml
+++ b/deploy/helm/provenance-stack/templates/api-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: "{{ include \"provenance-stack.imageRef\" (dict \"repository\" .Values.api.image.repository \"tag\" .Values.api.image.tag \"digest\" .Values.api.image.digest) }}"
+          image: {{ include "provenance-stack.imageRef" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.api.containerPort }}

--- a/deploy/helm/provenance-stack/templates/api-service.yaml
+++ b/deploy/helm/provenance-stack/templates/api-service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "provenance-stack.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.api.containerPort }}"
+    prometheus.io/path: "/metrics"
 spec:
   type: {{ .Values.api.service.type }}
   selector:

--- a/deploy/helm/provenance-stack/templates/networkpolicy.yaml
+++ b/deploy/helm/provenance-stack/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "provenance-stack.fullname" . }}-api
+  labels:
+    {{- include "provenance-stack.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: {{ .Values.api.containerPort }}

--- a/deploy/helm/provenance-stack/templates/pdb.yaml
+++ b/deploy/helm/provenance-stack/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if gt (int .Values.api.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "provenance-stack.fullname" . }}-api
+  labels:
+    {{- include "provenance-stack.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: api
+{{- end }}

--- a/deploy/helm/provenance-stack/templates/worker-deployment.yaml
+++ b/deploy/helm/provenance-stack/templates/worker-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: "{{ include \"provenance-stack.imageRef\" (dict \"repository\" .Values.worker.image.repository \"tag\" .Values.worker.image.tag \"digest\" .Values.worker.image.digest) }}"
+          image: {{ include "provenance-stack.imageRef" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest) | quote }}
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           command: ["python", "-m", "app.worker.main"]
           envFrom:

--- a/deploy/helm/provenance-stack/values.yaml
+++ b/deploy/helm/provenance-stack/values.yaml
@@ -12,7 +12,13 @@ api:
   service:
     type: ClusterIP
     port: 80
-  resources: {}
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   runSchedulerInApi: false
   env:
     requireApiKey: false
@@ -30,7 +36,13 @@ worker:
     tag: latest
     digest: ""
     pullPolicy: IfNotPresent
-  resources: {}
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
   env:
     workerEnableScheduler: true
     workerDrainWebhookQueue: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
       - ./backend:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -47,6 +52,11 @@ services:
       - ./backend:/app
     command: python -m app.worker.main
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
     healthcheck:
       test: ["CMD", "python", "-c", "import os; os.getpid()"]
       interval: 30s
@@ -71,6 +81,11 @@ services:
       - ./frontend:/app
       - /app/node_modules
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Add missing env vars, PR template, and link new operator docs in README
- Harden Helm chart with resource limits, PDB, NetworkPolicy, and Prometheus annotations
- Add Docker Compose resource limits and fix Helm template quoting

## Type of Change
- [x] Infrastructure / CI
- [x] Documentation

## Changes

| File | Change |
|------|--------|
| `.env.example` | Add `APT_ENABLE_PROMETHEUS` |
| `README.md` | Link 3 new docs, update tech table for Prometheus |
| `.github/PULL_REQUEST_TEMPLATE.md` | New PR template |
| `values.yaml` | Resource requests/limits for api and worker |
| `templates/pdb.yaml` | PodDisruptionBudget (when replicas > 1) |
| `templates/networkpolicy.yaml` | Ingress-only NetworkPolicy for api |
| `templates/api-service.yaml` | Prometheus scrape annotations |
| `templates/api-deployment.yaml` | Fix Helm template quoting |
| `templates/worker-deployment.yaml` | Fix Helm template quoting |
| `docker-compose.yml` | CPU/memory limits for backend, worker, frontend |

## Test Plan
- [x] `helm template` renders all resources without errors
- [x] `docker compose config` validates cleanly
- [x] CI pipeline