### PR TITLE
chore: add secrets baseline, release workflow, and project polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,17 @@ jobs:
           path: frontend/test-results/
           retention-days: 7
 
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Lint chart
+        run: helm lint deploy/helm/provenance-stack/
+      - name: Template chart
+        run: helm template test deploy/helm/provenance-stack/ > /dev/null
+
   public-benchmark:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline --no-merges)
+          else
+            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..HEAD")
+          fi
+
+          {
+            echo "notes<<EOF"
+            echo "## What's Changed"
+            echo ""
+            echo "$COMMITS" | while IFS= read -r line; do
+              echo "- $line"
+            done
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ github.ref_name }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "v${{ steps.version.outputs.version }}"
+          body: ${{ steps.notes.outputs.notes }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,560 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.lock$",
+        "\\.jsonl$",
+        "benchmark/",
+        "\\.secrets\\.baseline$",
+        "node_modules/",
+        "\\.venv/",
+        "\\.next/",
+        "\\.pytest_cache/",
+        "\\.ruff_cache/",
+        "frontend/tsconfig\\.tsbuildinfo"
+      ]
+    }
+  ],
+  "results": {
+    ".env.example": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".env.example",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    ".github/workflows/ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 54
+      }
+    ],
+    "DEVELOPMENT.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "DEVELOPMENT.md",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 137
+      }
+    ],
+    "backend/.env": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/.env",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/.env",
+        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "backend/alembic/versions/66cbf0fe8d26_create_analyses_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/alembic/versions/66cbf0fe8d26_create_analyses_table.py",
+        "hashed_secret": "39a7d31f07ab5ae1833b6e312553f0d6b3905a00",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "backend/alembic/versions/9d9f3c2e7f11_create_audit_events_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/alembic/versions/9d9f3c2e7f11_create_audit_events_table.py",
+        "hashed_secret": "289f46bd3583719ba709179c23c26a67807aa393",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/alembic/versions/9d9f3c2e7f11_create_audit_events_table.py",
+        "hashed_secret": "39a7d31f07ab5ae1833b6e312553f0d6b3905a00",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/evidence/runs/20260215_125834/pipeline_manifest.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/20260215_125834/pipeline_manifest.json",
+        "hashed_secret": "a5d3f29377e61c7c1955857b7c4118bc9aac67e9",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "backend/evidence/runs/comparisons/run_f45_vs_30d_snapshot.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/comparisons/run_f45_vs_30d_snapshot.json",
+        "hashed_secret": "0617bbe93a4c60f977ca49bf3fb21d6fc7b65ff3",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/comparisons/run_f45_vs_30d_snapshot.json",
+        "hashed_secret": "a9bc5eb08f8f5f57ffcfbd4dcff1fe9aebd9b391",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "backend/evidence/runs/comparisons_smoke/testweekly_20260216_102350_vs_testweekly_20260216_102400.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/comparisons_smoke/testweekly_20260216_102350_vs_testweekly_20260216_102400.json",
+        "hashed_secret": "8caf722a965481f83d40a8847aebe05cef072829",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/comparisons_smoke/testweekly_20260216_102350_vs_testweekly_20260216_102400.json",
+        "hashed_secret": "d6279e9c8f2e097256580aaa86f0ea4354c09323",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "backend/evidence/runs/manual_14d/run_f45db14e6340/pipeline_manifest.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/manual_14d/run_f45db14e6340/pipeline_manifest.json",
+        "hashed_secret": "0617bbe93a4c60f977ca49bf3fb21d6fc7b65ff3",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_14d/run_f45db14e6340/pipeline_manifest.json",
+        "hashed_secret": "5922f142e2a894099ba14ebd4b6401b80834e9c6",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_14d/run_f45db14e6340/pipeline_manifest.json",
+        "hashed_secret": "6c5134adcfd976f17574c32ced6cfbb6793451ad",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_14d/run_f45db14e6340/pipeline_manifest.json",
+        "hashed_secret": "6365507d086001fcafbaf92be39d93ae018d84f5",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/evidence/runs/manual_30d_input/run_30d_snapshot/pipeline_manifest.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/manual_30d_input/run_30d_snapshot/pipeline_manifest.json",
+        "hashed_secret": "a9bc5eb08f8f5f57ffcfbd4dcff1fe9aebd9b391",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_30d_input/run_30d_snapshot/pipeline_manifest.json",
+        "hashed_secret": "c1c79c32e17d39d4299e226d64b65c19bc541721",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_30d_input/run_30d_snapshot/pipeline_manifest.json",
+        "hashed_secret": "5fc633422ccb9e0c4ec4eb84f63e666f64127893",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/manual_30d_input/run_30d_snapshot/pipeline_manifest.json",
+        "hashed_secret": "60c98d3998c371eb643cf04e0c8ef11a39c60ac9",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/evidence/runs/weekly_smoke/latest_summary.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/latest_summary.json",
+        "hashed_secret": "d6279e9c8f2e097256580aaa86f0ea4354c09323",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/latest_summary.json",
+        "hashed_secret": "8caf722a965481f83d40a8847aebe05cef072829",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "backend/evidence/runs/weekly_smoke/testweekly_20260216_102350/pipeline_manifest.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102350/pipeline_manifest.json",
+        "hashed_secret": "8caf722a965481f83d40a8847aebe05cef072829",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102350/pipeline_manifest.json",
+        "hashed_secret": "dd8070dd11d83512d5efbeafd214e503da87a297",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102350/pipeline_manifest.json",
+        "hashed_secret": "a7cbf70aebe4372beaa8924f85c5e686e7cf3f94",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102350/pipeline_manifest.json",
+        "hashed_secret": "7127c91258a795c597842ffd98e10d8586fa532c",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/evidence/runs/weekly_smoke/testweekly_20260216_102400/pipeline_manifest.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102400/pipeline_manifest.json",
+        "hashed_secret": "d6279e9c8f2e097256580aaa86f0ea4354c09323",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102400/pipeline_manifest.json",
+        "hashed_secret": "dd8070dd11d83512d5efbeafd214e503da87a297",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102400/pipeline_manifest.json",
+        "hashed_secret": "a7cbf70aebe4372beaa8924f85c5e686e7cf3f94",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/evidence/runs/weekly_smoke/testweekly_20260216_102400/pipeline_manifest.json",
+        "hashed_secret": "60ecd6d8c147fc10f0c26fd6217cc701dc202a3c",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/tests/test_api_endpoints.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/test_api_endpoints.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 330
+      }
+    ],
+    "deploy/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "508ed4d8d528488d824c70b9365de983946c3534",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "2664d0e330b34a6b1a78fa9d7bacfbf601826de7",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "e774a9d088f5da3865a8abd94f81d34bb4a228fc",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "1f79aa9d48d8dffd07ebcb11435996005fbee212",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "d032457b49cf8bfa8b27a0a1409f14bbb7c12d6f",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "459363b0799cdb98b2048e88adee0825dbc5d698",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "118be9fae2999cc2848a1b32d7c243249bb9c2f6",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "51b1420db6c51113161d6a40caf1bfc21013ff7d",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "8825ac5a8ee39c1ec5d84a0f19cfa8e7a0b84755",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "79df04f046234717d29bdcf15304b7658869299a",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "4d9da40a8988fbd74773b437ca5bf61f96af3478",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/README.md",
+        "hashed_secret": "a8565cf5219d3a6fa83ac9620f0c55d0ef580eec",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "deploy/helm/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "deploy/helm/README.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "deploy/helm/provenance-stack/templates/_helpers.tpl": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "deploy/helm/provenance-stack/templates/_helpers.tpl",
+        "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "deploy/helm/provenance-stack/values.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/helm/provenance-stack/values.yaml",
+        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/helm/provenance-stack/values.yaml",
+        "hashed_secret": "6da9c4689bc2b24fdaf94f4eee7f023a9e75072f",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "deploy/terraform/aws/terraform.tfvars.example": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/terraform/aws/terraform.tfvars.example",
+        "hashed_secret": "bb66747581d20f44471efd52646c11fb94c068fe",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "docs/COST_GOVERNANCE.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/COST_GOVERNANCE.md",
+        "hashed_secret": "5d99d808889a20189d6e1b7cb39dd7f15224da5c",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "docs/PERFORMANCE_TUNING.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/PERFORMANCE_TUNING.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "docs/TROUBLESHOOTING.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/TROUBLESHOOTING.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ]
+  },
+  "generated_at": "2026-02-21T08:04:06Z"
+}

--- a/deploy/helm/provenance-stack/Chart.yaml
+++ b/deploy/helm/provenance-stack/Chart.yaml
@@ -4,3 +4,13 @@ description: Provenance-as-a-Service stack (API + worker + optional Postgres)
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+home: https://github.com/ogulcanaydogan/AI-Provenance-Tracker
+sources:
+  - https://github.com/ogulcanaydogan/AI-Provenance-Tracker
+maintainers:
+  - name: Ogulcan Aydogan
+keywords:
+  - ai-detection
+  - provenance
+  - deepfake
+  - content-authenticity

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,35 @@
+# Dependencies
+node_modules/
+
+# Build output
+.next/
+out/
+
+# Testing
+coverage/
+test-results/
+playwright-report/
+e2e/
+src/**/*.test.ts
+src/**/*.test.tsx
+src/__tests__/
+playwright.config.ts
+vitest.config.ts
+
+# Dev tools
+.eslintcache
+.turbo/
+*.tsbuildinfo
+
+# Env files
+.env
+.env.*
+
+# Git and docs
+.git/
+.gitignore
+README.md
+
+# IDE
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- Generate `.secrets.baseline` so detect-secrets pre-commit hook works out of the box
- Add `frontend/.dockerignore` to keep Docker images lean (excludes node_modules, .next, tests)
- Add GitHub Release workflow for automated release notes on version tags
- Enrich Helm `Chart.yaml` with home, sources, maintainers, keywords metadata
- Add `helm-lint` CI job that validates chart linting and template rendering

## Type of Change
- [x] Infrastructure / CI
- [x] Documentation

## Test Plan
- [x] `helm lint` and `helm template` pass locally
- [x] CI pipeline (new helm-lint job validates chart)
- [x] `.secrets.baseline` generated with proper exclusions