### PR TITLE
feat(training): route A100 run + shard V100 sweep profiles

### DIFF
--- a/.github/workflows/text-training.yml
+++ b/.github/workflows/text-training.yml
@@ -19,13 +19,26 @@ on:
         description: "False-positive penalty weight for human class"
         required: true
         default: "1.7"
+      v100_profile:
+        description: "V100 profile (all runs all 5 shards)"
+        required: true
+        type: choice
+        options:
+          - all
+          - v11_fp_sweep_lr2e5_pen17
+          - v11_fp_sweep_lr3e5_pen20
+          - v11_fp_sweep_lr15e5_pen15
+          - v11_fp_sweep_lr25e5_pen18
+          - v11_fp_sweep_lr1e5_pen22
+        default: all
 
 permissions:
   contents: read
 
 jobs:
-  train-text:
-    runs-on: [self-hosted, linux, x64, spark]
+  train-a100:
+    if: ${{ github.event.inputs.training_mode == 'a100_single' }}
+    runs-on: [self-hosted, linux, x64, spark, a100]
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v6
@@ -47,17 +60,11 @@ jobs:
           make build-hard-negatives INCLUDE_FALSE_NEGATIVES=1 || true
 
       - name: Run A100 targeted fine-tune
-        if: ${{ github.event.inputs.training_mode == 'a100_single' }}
         run: |
           make train-text-a100 \
             MAX_TRAIN_SAMPLES="${{ github.event.inputs.max_train_samples }}" \
             FP_PENALTY="${{ github.event.inputs.fp_penalty }}" \
             RUN_NAME="v11_text_fp_a100_${{ github.run_id }}"
-
-      - name: Run V100 sweep
-        if: ${{ github.event.inputs.training_mode == 'v100_sweep' }}
-        run: |
-          make sweep-text-v100 EXECUTE=1
 
       - name: Refresh calibration after training
         run: |
@@ -67,7 +74,63 @@ jobs:
       - name: Upload training artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: text-training-artifacts
+          name: text-training-artifacts-a100
+          path: |
+            backend/evidence/models/text/**/training_manifest.json
+            backend/evidence/models/text/latest.json
+            backend/evidence/calibration/text/latest_text_calibration.json
+            backend/evidence/calibration/text/quality_gate.json
+            backend/evidence/calibration/text/quality_gate.md
+          retention-days: 30
+
+  train-v100-sweep:
+    if: ${{ github.event.inputs.training_mode == 'v100_sweep' }}
+    runs-on: [self-hosted, linux, x64, spark, v100]
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - v11_fp_sweep_lr2e5_pen17
+          - v11_fp_sweep_lr3e5_pen20
+          - v11_fp_sweep_lr15e5_pen15
+          - v11_fp_sweep_lr25e5_pen18
+          - v11_fp_sweep_lr1e5_pen22
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install backend ML dependencies
+        run: |
+          cd backend
+          pip install -e ".[dev,ml]"
+
+      - name: Build text dataset
+        run: |
+          make build-text-dataset
+
+      - name: Build hard negatives from latest benchmark
+        run: |
+          make build-hard-negatives INCLUDE_FALSE_NEGATIVES=1 || true
+
+      - name: Run V100 sweep shard
+        if: ${{ github.event.inputs.v100_profile == 'all' || github.event.inputs.v100_profile == matrix.profile }}
+        run: |
+          make sweep-text-v100 EXECUTE=1 PROFILE="${{ matrix.profile }}"
+
+      - name: Refresh calibration after training
+        if: ${{ github.event.inputs.v100_profile == 'all' || github.event.inputs.v100_profile == matrix.profile }}
+        run: |
+          make calibrate-text MIN_SAMPLES=120 MIN_DOMAIN_SAMPLES=40
+          make text-quality-gate MAX_FP_RATE=0.08 MAX_ECE=0.08
+
+      - name: Upload training artifacts
+        if: ${{ github.event.inputs.v100_profile == 'all' || github.event.inputs.v100_profile == matrix.profile }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: text-training-artifacts-${{ matrix.profile }}
           path: |
             backend/evidence/models/text/**/training_manifest.json
             backend/evidence/models/text/latest.json

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "  make build-hard-negatives Extract hard FP/FN samples from scored benchmark outputs"
 	@echo "  make train-text-model Run targeted text fine-tuning"
 	@echo "  make train-text-a100 Recommended A100 profile for targeted fine-tuning"
-	@echo "  make sweep-text-v100 Print/execute V100 hyperparameter sweep commands"
+	@echo "  make sweep-text-v100 Print/execute V100 hyperparameter sweep commands (PROFILE=<name>|all)"
 	@echo "  make cost-governance Generate CI/CD spend governance snapshot"
 	@echo "  make package-policy Enforce dependency source allow/deny policy"
 	@echo "  make slo-report      Generate observability SLO report from workflow history"
@@ -142,4 +142,4 @@ train-text-a100:
 	$(MAKE) train-text-model BASE_MODEL="$${BASE_MODEL:-distilroberta-base}" EPOCHS="$${EPOCHS:-3}" TRAIN_BATCH_SIZE="$${TRAIN_BATCH_SIZE:-32}" EVAL_BATCH_SIZE="$${EVAL_BATCH_SIZE:-64}" RUN_NAME="$${RUN_NAME:-v11_text_fp_a100}" FP_PENALTY="$${FP_PENALTY:-1.8}" LEARNING_RATE="$${LEARNING_RATE:-2e-5}"
 
 sweep-text-v100:
-	python3 backend/scripts/sweep_text_training.py --dataset "$${DATASET:-backend/evidence/samples/text_labeled_expanded.jsonl}" --hard-negatives "$${HARD_NEGATIVES:-backend/evidence/samples/text_hard_negatives.jsonl}" --output-dir "$${OUTPUT_DIR:-backend/evidence/models/text}" --base-model "$${BASE_MODEL:-distilroberta-base}" $${EXECUTE:+--execute}
+	python3 backend/scripts/sweep_text_training.py --dataset "$${DATASET:-backend/evidence/samples/text_labeled_expanded.jsonl}" --hard-negatives "$${HARD_NEGATIVES:-backend/evidence/samples/text_hard_negatives.jsonl}" --output-dir "$${OUTPUT_DIR:-backend/evidence/models/text}" --base-model "$${BASE_MODEL:-distilroberta-base}" --profile "$${PROFILE:-all}" $${EXECUTE:+--execute}

--- a/backend/scripts/sweep_text_training.py
+++ b/backend/scripts/sweep_text_training.py
@@ -7,6 +7,22 @@ import argparse
 import subprocess
 from pathlib import Path
 
+PROFILE_GRID: dict[str, dict[str, str]] = {
+    "v11_fp_sweep_lr2e5_pen17": {"learning_rate": "2e-5", "fp_penalty": "1.7", "seed": "42"},
+    "v11_fp_sweep_lr3e5_pen20": {"learning_rate": "3e-5", "fp_penalty": "2.0", "seed": "43"},
+    "v11_fp_sweep_lr15e5_pen15": {
+        "learning_rate": "1.5e-5",
+        "fp_penalty": "1.5",
+        "seed": "44",
+    },
+    "v11_fp_sweep_lr25e5_pen18": {
+        "learning_rate": "2.5e-5",
+        "fp_penalty": "1.8",
+        "seed": "45",
+    },
+    "v11_fp_sweep_lr1e5_pen22": {"learning_rate": "1e-5", "fp_penalty": "2.2", "seed": "46"},
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -23,6 +39,17 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output-dir", default="backend/evidence/models/text")
     parser.add_argument("--base-model", default="distilroberta-base")
+    parser.add_argument(
+        "--profile",
+        choices=["all", *PROFILE_GRID.keys()],
+        default="all",
+        help="Run all profiles or only one named profile.",
+    )
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="Print available profile names and exit.",
+    )
     return parser.parse_args()
 
 
@@ -49,53 +76,40 @@ def _commands(args: argparse.Namespace) -> list[list[str]]:
         "0",
     ]
 
-    profiles = [
-        [
-            "--run-name",
-            "v11_fp_sweep_lr2e5_pen17",
-            "--learning-rate",
-            "2e-5",
-            "--fp-penalty",
-            "1.7",
-            "--seed",
-            "42",
-        ],
-        [
-            "--run-name",
-            "v11_fp_sweep_lr3e5_pen20",
-            "--learning-rate",
-            "3e-5",
-            "--fp-penalty",
-            "2.0",
-            "--seed",
-            "43",
-        ],
-        [
-            "--run-name",
-            "v11_fp_sweep_lr15e5_pen15",
-            "--learning-rate",
-            "1.5e-5",
-            "--fp-penalty",
-            "1.5",
-            "--seed",
-            "44",
-        ],
-    ]
-
-    return [base + profile for profile in profiles]
+    profile_names = list(PROFILE_GRID.keys()) if args.profile == "all" else [args.profile]
+    commands: list[list[str]] = []
+    for profile_name in profile_names:
+        profile = PROFILE_GRID[profile_name]
+        commands.append(
+            base
+            + [
+                "--run-name",
+                profile_name,
+                "--learning-rate",
+                profile["learning_rate"],
+                "--fp-penalty",
+                profile["fp_penalty"],
+                "--seed",
+                profile["seed"],
+            ]
+        )
+    return commands
 
 
 def run() -> int:
     args = parse_args()
-    commands = _commands(args)
+    if args.list_profiles:
+        for profile_name in PROFILE_GRID:
+            print(profile_name)
+        return 0
 
+    commands = _commands(args)
     for command in commands:
         print(" ".join(command))
         if args.execute:
             result = subprocess.run(command, check=False)
             if result.returncode != 0:
                 return result.returncode
-
     return 0
 
 

--- a/backend/tests/test_sweep_text_training_script.py
+++ b/backend/tests/test_sweep_text_training_script.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import types
+from pathlib import Path
+
+
+def _load_script_module(script_name: str) -> types.ModuleType:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(script_name.replace(".py", ""), script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sweep_commands_all_profiles() -> None:
+    module = _load_script_module("sweep_text_training.py")
+    args = argparse.Namespace(
+        execute=False,
+        dataset="backend/evidence/samples/text_labeled_expanded.jsonl",
+        hard_negatives="backend/evidence/samples/text_hard_negatives.jsonl",
+        output_dir="backend/evidence/models/text",
+        base_model="distilroberta-base",
+        profile="all",
+        list_profiles=False,
+    )
+
+    commands = module._commands(args)
+    assert len(commands) == len(module.PROFILE_GRID)
+    assert all("backend/scripts/train_text_detector.py" in command for command in commands)
+
+
+def test_sweep_commands_single_profile() -> None:
+    module = _load_script_module("sweep_text_training.py")
+    args = argparse.Namespace(
+        execute=False,
+        dataset="backend/evidence/samples/text_labeled_expanded.jsonl",
+        hard_negatives="backend/evidence/samples/text_hard_negatives.jsonl",
+        output_dir="backend/evidence/models/text",
+        base_model="distilroberta-base",
+        profile="v11_fp_sweep_lr25e5_pen18",
+        list_profiles=False,
+    )
+
+    commands = module._commands(args)
+    assert len(commands) == 1
+    assert "--run-name" in commands[0]
+    assert "v11_fp_sweep_lr25e5_pen18" in commands[0]
+
+
+def test_list_profiles_mode(capsys) -> None:  # type: ignore[no-untyped-def]
+    module = _load_script_module("sweep_text_training.py")
+
+    import sys
+
+    original = sys.argv
+    sys.argv = ["sweep_text_training.py", "--list-profiles"]
+    try:
+        rc = module.run()
+    finally:
+        sys.argv = original
+
+    assert rc == 0
+    output_lines = [line.strip() for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert output_lines == list(module.PROFILE_GRID.keys())

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -13,6 +13,13 @@ This runbook covers targeted text detector fine-tuning for v1.1 false-positive s
 - **A100 (single run):** primary fine-tune candidate.
 - **V100 pool (x5):** hyperparameter sweep and robustness sweeps.
 
+## Runner Labels (GitHub Actions)
+
+Configure self-hosted GPU runners with explicit labels so the workflow routes correctly:
+
+- A100 host: `self-hosted,linux,x64,spark,a100`
+- Each V100 host: `self-hosted,linux,x64,spark,v100`
+
 ## Data Preparation
 
 ```bash
@@ -47,6 +54,18 @@ Execute sweep:
 
 ```bash
 make sweep-text-v100 EXECUTE=1
+```
+
+Execute one specific V100 profile:
+
+```bash
+make sweep-text-v100 EXECUTE=1 PROFILE=v11_fp_sweep_lr25e5_pen18
+```
+
+List available sweep profiles:
+
+```bash
+python3 backend/scripts/sweep_text_training.py --list-profiles
 ```
 
 ## Post-Training Calibration and Gate


### PR DESCRIPTION
## Summary
- route A100 training runs to `a100`-labeled self-hosted runners
- shard V100 sweep into 5 explicit profiles for parallel execution on `v100` runners
- add profile selection/listing support to sweep script and `make sweep-text-v100`
- document runner labels and profile usage in training runbook

## Validation
- `cd backend && .venv/bin/ruff check scripts/sweep_text_training.py tests/test_sweep_text_training_script.py`
- `cd backend && .venv/bin/python -m pytest tests/test_sweep_text_training_script.py --no-cov -q`
- `python3 backend/scripts/sweep_text_training.py --list-profiles`
