### PR TITLE
fix(training): run only selected V100 profile job

### DIFF
--- a/.github/workflows/text-training.yml
+++ b/.github/workflows/text-training.yml
@@ -84,18 +84,13 @@ jobs:
           retention-days: 30
 
   train-v100-sweep:
-    if: ${{ github.event.inputs.training_mode == 'v100_sweep' && (github.event.inputs.v100_profile == 'all' || github.event.inputs.v100_profile == matrix.profile) }}
+    if: ${{ github.event.inputs.training_mode == 'v100_sweep' }}
     runs-on: [self-hosted, linux, x64, spark, v100]
     timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
-        profile:
-          - v11_fp_sweep_lr2e5_pen17
-          - v11_fp_sweep_lr3e5_pen20
-          - v11_fp_sweep_lr15e5_pen15
-          - v11_fp_sweep_lr25e5_pen18
-          - v11_fp_sweep_lr1e5_pen22
+        profile: ${{ fromJson(github.event.inputs.v100_profile == 'all' && '["v11_fp_sweep_lr2e5_pen17","v11_fp_sweep_lr3e5_pen20","v11_fp_sweep_lr15e5_pen15","v11_fp_sweep_lr25e5_pen18","v11_fp_sweep_lr1e5_pen22"]' || format('["{0}"]', github.event.inputs.v100_profile)) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- move profile filter to job-level condition for train-v100-sweep
- prevent non-selected matrix jobs from reserving V100 runners
- keep all mode behavior unchanged

## Why
Single-profile dispatch should consume only one available V100 runner instead of queuing full matrix.
