### PR TITLE
fix(training): resolve model path from latest manifest

### DIFF
--- a/.github/workflows/text-training.yml
+++ b/.github/workflows/text-training.yml
@@ -74,7 +74,15 @@ jobs:
 
           latest_path = Path("backend/evidence/models/text/latest.json")
           payload = json.loads(latest_path.read_text(encoding="utf-8"))
-          print(payload.get("model_path", ""))
+          model_path = payload.get("model_path")
+          if model_path:
+              print(model_path)
+          else:
+              manifest = payload.get("manifest")
+              if manifest:
+                  print(str(Path(manifest).parent))
+              else:
+                  print("")
           PY
           )"
           if [ -z "$MODEL_PATH" ]; then
@@ -141,7 +149,15 @@ jobs:
 
           latest_path = Path("backend/evidence/models/text/latest.json")
           payload = json.loads(latest_path.read_text(encoding="utf-8"))
-          print(payload.get("model_path", ""))
+          model_path = payload.get("model_path")
+          if model_path:
+              print(model_path)
+          else:
+              manifest = payload.get("manifest")
+              if manifest:
+                  print(str(Path(manifest).parent))
+              else:
+                  print("")
           PY
           )"
           if [ -z "$MODEL_PATH" ]; then


### PR DESCRIPTION
## What\n- update training workflow model-path resolver to support both latest.json formats\n  - legacy: `model_path`\n  - current: `manifest` pointer\n- keep calibration step pointed at the just-trained artifact\n\n## Why\nSingle V100 profile run failed at `Resolve trained model path` because `latest.json` now stores `manifest` not `model_path`.\n\n## Validation\n- workflow YAML updated in both A100 and V100 jobs\n- rerun training after merge