### PR TITLE
fix(training): strict gate accuracy + GPU pin input

### DIFF
--- a/.github/workflows/text-training.yml
+++ b/.github/workflows/text-training.yml
@@ -31,6 +31,10 @@ on:
           - v11_fp_sweep_lr25e5_pen18
           - v11_fp_sweep_lr1e5_pen22
         default: all
+      cuda_visible_devices:
+        description: "CUDA_VISIBLE_DEVICES value to pin training GPU(s)"
+        required: true
+        default: "0"
 
 permissions:
   contents: read
@@ -40,6 +44,8 @@ jobs:
     if: ${{ github.event.inputs.training_mode == 'a100_single' }}
     runs-on: [self-hosted, linux, x64, spark, a100]
     timeout-minutes: 360
+    env:
+      CUDA_VISIBLE_DEVICES: ${{ github.event.inputs.cuda_visible_devices }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -114,6 +120,8 @@ jobs:
     if: ${{ github.event.inputs.training_mode == 'v100_sweep' }}
     runs-on: [self-hosted, linux, x64, spark, v100]
     timeout-minutes: 360
+    env:
+      CUDA_VISIBLE_DEVICES: ${{ github.event.inputs.cuda_visible_devices }}
     strategy:
       fail-fast: false
       matrix:

--- a/backend/scripts/check_text_quality_gate.py
+++ b/backend/scripts/check_text_quality_gate.py
@@ -27,6 +27,16 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _to_float(value: Any, default: float) -> float:
+    """Parse numeric values without treating 0.0 as missing."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _failures(payload: dict[str, Any], args: argparse.Namespace) -> list[str]:
     failures: list[str] = []
 
@@ -37,15 +47,15 @@ def _failures(payload: dict[str, Any], args: argparse.Namespace) -> list[str]:
     best_metrics = (
         payload.get("best_metrics", {}) if isinstance(payload.get("best_metrics"), dict) else {}
     )
-    fp_rate = float(best_metrics.get("fp_rate", 1.0) or 1.0)
+    fp_rate = _to_float(best_metrics.get("fp_rate"), 1.0)
     if fp_rate > float(args.max_fp_rate):
         failures.append(f"fp_rate {fp_rate:.4f} > max_fp_rate {float(args.max_fp_rate):.4f}")
 
-    ece = float(payload.get("ece", 1.0) or 1.0)
+    ece = _to_float(payload.get("ece"), 1.0)
     if ece > float(args.max_ece):
         failures.append(f"ece {ece:.4f} > max_ece {float(args.max_ece):.4f}")
 
-    margin = float(payload.get("recommended_uncertainty_margin", 1.0) or 1.0)
+    margin = _to_float(payload.get("recommended_uncertainty_margin"), 1.0)
     if margin > float(args.max_uncertainty_margin):
         failures.append(
             f"uncertainty_margin {margin:.4f} > max_uncertainty_margin {float(args.max_uncertainty_margin):.4f}"
@@ -97,9 +107,9 @@ def run() -> int:
         "report": str(report_path),
         "status": "ok",
         "sample_count": int(payload.get("sample_count", 0) or 0),
-        "fp_rate": float(best_metrics.get("fp_rate", 1.0) or 1.0),
-        "ece": float(payload.get("ece", 1.0) or 1.0),
-        "uncertainty_margin": float(payload.get("recommended_uncertainty_margin", 1.0) or 1.0),
+        "fp_rate": _to_float(best_metrics.get("fp_rate"), 1.0),
+        "ece": _to_float(payload.get("ece"), 1.0),
+        "uncertainty_margin": _to_float(payload.get("recommended_uncertainty_margin"), 1.0),
         "failures": _failures(payload, args),
     }
     if summary["failures"]:


### PR DESCRIPTION
## Changes
- fix text quality gate parsing so `best_metrics.fp_rate=0.0` is preserved (no false fallback to 1.0)
- add `workflow_dispatch` input `cuda_visible_devices` (default `0`) to text training workflow
- set `CUDA_VISIBLE_DEVICES` at job env for both `train-a100` and `train-v100-sweep`

## Validation
- local gate script check with fp_rate=0.0 now returns status=ok
- runner preflight on ai-training-2 confirms GPU0 is compute-idle

## Plan alignment
Implements strict-gate + single GPU pinning readiness for V100 profile sequence.
