### PR TITLE
fix: use relative timestamp in evaluation endpoint test to stop time-bombing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Evaluation endpoint test (`test_evaluation_endpoint_returns_registered_reports`) no longer time-bombs: seeded report now uses a relative timestamp 30 days back so it stays inside the rolling 90-day evaluation window regardless of when the test runs.
 - Removed obsolete `version` key from `docker-compose.yml`
 
 ## [0.1.0] — 2025-06-01

--- a/backend/tests/test_api_endpoints.py
+++ b/backend/tests/test_api_endpoints.py
@@ -3,6 +3,7 @@ import json
 import math
 import struct
 import wave
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -591,7 +592,7 @@ async def test_evaluation_endpoint_returns_registered_reports(client: AsyncClien
     settings.calibration_reports_dir = str(tmp_path)
     try:
         payload = {
-            "generated_at": "2026-02-15T12:00:00+00:00",
+            "generated_at": (datetime.now(UTC) - timedelta(days=30)).isoformat(),
             "content_type": "text",
             "sample_count": 40,
             "recommended_threshold": 0.55,


### PR DESCRIPTION
## Summary

- The test `test_evaluation_endpoint_returns_registered_reports` seeded a report with `generated_at = 2026-02-15T12:00:00+00:00` and queried `?days=90`. `EvaluationStore.get_summary` computes a rolling cutoff at `now - timedelta(days=89)`; as of 2026-05-19 that cutoff is ~2026-02-19, so the literal 2026-02-15 seed slipped outside the window and the endpoint correctly returned 0 reports, failing the `assert total_reports == 1`.
- Replaced the hardcoded ISO string with `(datetime.now(UTC) - timedelta(days=30)).isoformat()` so the seed is always 30 days old and stays inside any `?days=90` query for the foreseeable future. No endpoint or service code changed.
- This has been the sole reason `backend-test` has failed on every PR (including the recent docs PRs #83 and #84 that had to be bypass-merged).

## Test plan

- [ ] `backend-test` CI job shows SUCCESS (not FAILURE) on this PR
- [ ] All other `test_api_endpoints.py` tests continue passing
- [ ] PR #82 `backend-test` failure also resolves once this lands on main