### PR TITLE
ci: stop scheduling backend-dependent watch workflows

### DIFF
--- a/.github/workflows/publish-leaderboard.yml
+++ b/.github/workflows/publish-leaderboard.yml
@@ -1,9 +1,9 @@
 name: Publish Benchmark Leaderboard
 
 on:
+  # Scheduled runs removed: the backend can't boot unattended in CI, so the cron
+  # run always failed. Trigger manually once the backend starts reliably.
   workflow_dispatch:
-  schedule:
-    - cron: "30 2 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/text-quality-drift-watch.yml
+++ b/.github/workflows/text-quality-drift-watch.yml
@@ -19,8 +19,8 @@ on:
           - normal
           - drill_fail
         default: normal
-  schedule:
-    - cron: "15 3 * * *"
+  # Scheduled runs removed: the backend can't boot unattended in CI, so the cron
+  # run always failed. Trigger manually once the backend starts reliably.
 
 permissions:
   contents: read


### PR DESCRIPTION
`Text Quality Drift Watch` and `Publish Benchmark Leaderboard` start the backend and poll `127.0.0.1:8000`, which never boots unattended in CI, so every scheduled run failed with `Backend failed to start`.

Switch both to `workflow_dispatch` only so they run on demand instead of failing daily. No logic change otherwise. The CVE gate in `verify-production-images` is intentionally left as-is (it reports real critical CVEs and should be fixed by refreshing the images, not silenced).