### PR TITLE
fix(docker): bump base to bookworm and apply OS security patches

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
+# Apply OS security patches then install build deps.
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends build-essential curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install Python dependencies first (better caching)


### PR DESCRIPTION
Switches `python:3.11-slim` to `python:3.11-slim-bookworm` and runs `apt-get upgrade` before installing build deps. Clears the OS-level CVEs (critical=10, high=314) that `Verify Production Images` had been failing on.