### PR TITLE
fix: retry cosign sign/attest on transient GHCR errors

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -175,7 +175,8 @@ jobs:
           SBOM_PATH: sbom-${{ matrix.component }}-${{ github.sha }}.spdx.json
         run: |
           set -euo pipefail
-          cosign attest --yes --type spdxjson --predicate "${SBOM_PATH}" "${IMAGE_SHA_TAG}"
+          retry() { local n; for n in 1 2 3 4 5; do "$@" && return 0; echo "::warning::cosign attempt ${n} failed (transient registry/GHCR error); retrying in $((n*15))s"; sleep $((n*15)); done; return 1; }
+          retry cosign attest --yes --type spdxjson --predicate "${SBOM_PATH}" "${IMAGE_SHA_TAG}"
       - name: Scan image vulnerabilities (Trivy JSON)
         env:
           IMAGE_SHA_TAG: ghcr.io/${{ github.repository_owner }}/provenance-${{ matrix.component }}:${{ github.sha }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -158,8 +158,9 @@ jobs:
           IMAGE_LATEST_TAG: ghcr.io/${{ github.repository_owner }}/provenance-${{ matrix.component }}:latest
         run: |
           set -euo pipefail
-          cosign sign --yes "${IMAGE_SHA_TAG}"
-          cosign sign --yes "${IMAGE_LATEST_TAG}"
+          retry() { local n; for n in 1 2 3 4 5; do "$@" && return 0; echo "::warning::cosign attempt ${n} failed (transient registry/GHCR error); retrying in $((n*15))s"; sleep $((n*15)); done; return 1; }
+          retry cosign sign --yes "${IMAGE_SHA_TAG}"
+          retry cosign sign --yes "${IMAGE_LATEST_TAG}"
       - name: Generate SBOM (SPDX JSON)
         env:
           IMAGE_SHA_TAG: ghcr.io/${{ github.repository_owner }}/provenance-${{ matrix.component }}:${{ github.sha }}


### PR DESCRIPTION
GHCR referrers API intermittently returns 502 during keyless cosign sign/attest, failing image publish. Wrap sign and attest in a bounded retry so transient registry errors no longer fail the pipeline.