### PR TITLE
fix: retire dead Spark/DGX + a100 infra references

### DIFF
--- a/.github/workflows/deploy-spark-after-publish.yml
+++ b/.github/workflows/deploy-spark-after-publish.yml
@@ -15,7 +15,9 @@ concurrency:
 
 jobs:
   dispatch-deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    # Deploy chain disabled: Spark/DGX access ended; no live deploy target.
+    # Image publish + signing still run. Re-enable when a deploy target is configured.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -7,8 +7,6 @@ on:
         description: "Optional smoke target URL override"
         required: false
         default: ""
-  schedule:
-    - cron: "0 */6 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/text-training.yml
+++ b/.github/workflows/text-training.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   train-a100:
     if: ${{ github.event.inputs.training_mode == 'a100_single' }}
-    runs-on: [self-hosted, linux, x64, a100]
+    runs-on: [self-hosted, linux, x64, gpu]
     timeout-minutes: 360
     env:
       CUDA_VISIBLE_DEVICES: ${{ github.event.inputs.cuda_visible_devices }}


### PR DESCRIPTION
Access to the A100 box and DGX Spark ended (2+ months). Stop the CI from depending on infrastructure that no longer exists:

- prod-smoke: drop the every-6h schedule (it smoke-tested a service that was never deployed to the dead Spark, failing every cycle). Manual dispatch only.
- deploy-spark-after-publish: disable the deploy dispatch chain (no live target). Image publish + signing continue.
- text-training: relabel runner from `a100` to generic `gpu` so the incoming 3090 box can run it once registered.

The phantom `gpu-a100-01` self-hosted runner (online on an inaccessible host, a security risk on a public repo) has been deregistered. Dead SPARK_SSH_* secrets removed.