### PR TITLE
fix(deps): pin fastapi and instrumentator below breaking versions

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastapi>=0.109.0",
+    # fastapi 0.137 + prometheus-fastapi-instrumentator 8.0 break app startup
+    # with "'_IncludedRouter' object has no attribute 'path'" (Starlette router
+    # internals changed). Cap both below the breaking releases until upstream
+    # instrumentator supports the new router layout.
+    "fastapi>=0.109.0,<0.137",
     "uvicorn[standard]>=0.27.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
@@ -41,7 +45,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "redis>=5.0.1",
     "structlog>=24.1.0",
-    "prometheus-fastapi-instrumentator>=7.0.0",
+    "prometheus-fastapi-instrumentator>=7.0.0,<8.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,12 +1,15 @@
 # Core
-fastapi>=0.109.0
+# Pin fastapi/instrumentator below the versions that introduced the Starlette
+# _IncludedRouter change: fastapi 0.137 + prometheus-fastapi-instrumentator 8.0
+# break app startup with "'_IncludedRouter' object has no attribute 'path'".
+fastapi>=0.109.0,<0.137
 uvicorn[standard]>=0.27.0
 pydantic>=2.5.0
 pydantic-settings>=2.1.0
 python-multipart>=0.0.6
 httpx>=0.26.0
 structlog>=24.1.0
-prometheus-fastapi-instrumentator>=7.0.0
+prometheus-fastapi-instrumentator>=7.0.0,<8.0.0
 
 # Scientific computing
 numpy>=1.26.0


### PR DESCRIPTION
## Problem
Backend tests (`test_api_endpoints.py`, all of them) started failing in fresh CI with:
```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```
The app fails at startup. `prometheus-fastapi-instrumentator` iterates `app.routes` and reads `route.path`; **fastapi 0.137 / Starlette 1.3** changed included-router internals, and **instrumentator 8.0** trips over it.

## Fix
Pin both below the breaking versions (the loose `>=` constraints let CI pull breaking releases):
- `fastapi>=0.109.0,<0.137`
- `prometheus-fastapi-instrumentator>=7.0.0,<8.0.0`

Restores reproducible builds and unblocks the open dependabot PRs (#90, #87).