### PR TITLE
ci: tolerate X API failures in weekly evidence run

### DIFF
--- a/.github/workflows/weekly-evidence.yml
+++ b/.github/workflows/weekly-evidence.yml
@@ -73,13 +73,17 @@ jobs:
           X_MAX_REQUESTS_PER_RUN: ${{ steps.params.outputs.max_requests_per_run }}
         run: |
           cd backend
+          # The X API is an external dependency; an expired/invalid X_BEARER_TOKEN
+          # or an API outage (401/429/5xx) should degrade to a warning rather than
+          # turn the scheduled run red every week. Prior evidence is left in place.
           python scripts/run_weekly_talent_visa_cycle.py \
             --handle "${{ steps.params.outputs.handle }}" \
             --window-days "${{ steps.params.outputs.window_days }}" \
             --max-posts "${{ steps.params.outputs.max_posts }}" \
             --output-dir ./evidence/runs/weekly \
             --comparisons-dir ./evidence/runs/comparisons \
-            --summary-output ./evidence/runs/weekly/latest_summary.json
+            --summary-output ./evidence/runs/weekly/latest_summary.json \
+            || echo "::warning::weekly X evidence collection failed (X API unavailable or X_BEARER_TOKEN invalid/expired); leaving prior evidence in place"
       - name: Skip when token is not configured
         if: ${{ env.X_BEARER_TOKEN == '' }}
         run: echo "X_BEARER_TOKEN secret is not set; skipping weekly evidence run."
@@ -93,3 +97,4 @@ jobs:
             backend/evidence/runs/weekly/**
             backend/evidence/runs/comparisons/**
           retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem
`Weekly Talent Visa Evidence` (weekly-evidence.yml) has failed on every scheduled run (06-01 → 06-22) with `X API auth error (401): Unauthorized`. The workflow already skips gracefully when `X_BEARER_TOKEN` is **absent**, but when the token is **present but invalid/expired**, the collection step runs, hits the X API, and hard-fails — turning main red weekly.

## Fix
The X API is an external dependency, not a code gate. Mirror the report-only pattern used elsewhere in the portfolio:
- Append `|| echo "::warning::..."` to the weekly cycle command so an X API auth/availability failure (401/429/5xx) degrades to a warning instead of a red run.
- Add `if-no-files-found: warn` to the artifact upload so a run that produced no new evidence does not fail.

No other step is affected; the token-absent skip path is unchanged.

## Note
`X_BEARER_TOKEN` appears to be expired — **refresh the repository secret** to restore live weekly collection. This change only stops an expired token from turning main red every week.

## Verification
After merge: `gh workflow run weekly-evidence.yml` → the cycle step runs (token is set), the X API 401 is caught by the warning fallback, and the job is **green**.