### PR TITLE
chore(deps): ignore unsupported frontend majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,18 @@ updates:
           - "major"
           - "minor"
           - "patch"
+    # eslint-config-next does not yet support these majors: eslint 10 removes
+    # context.getFilename() used by its bundled eslint-plugin-react, lucide v1
+    # drops icons the UI imports, and typescript 6 is unverified. They break
+    # frontend-build, so block the major bumps until the ecosystem catches up
+    # (remove an entry to re-enable that major once supported).
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "javascript"


### PR DESCRIPTION
## Problem
The weekly npm rollup keeps re-proposing the same breaking majors — **eslint 10**, **typescript 6**, **lucide-react 1** — which fail `frontend-build` (eslint 10 removes `context.getFilename()` used by `eslint-config-next`'s bundled `eslint-plugin-react`; lucide v1 drops icons the UI imports). PR #87 reverted them manually two weeks ago; the same group returned as #98. Reverting weekly is whack-a-mole.

## Fix
Add a dependabot `ignore` for the major bumps of these three packages in the npm (`/frontend`) ecosystem. Future rollups will carry only the safe updates. Each entry has a comment; remove one to re-enable that major once `eslint-config-next` supports it.

Follow-up: **#98 will be closed** — its only non-breaking content is a vitest patch, which the next clean rollup will pick up.