### PR TITLE
docs: flagship polish (badges, community docs, Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,14 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
         run: |
           cd backend
-          pytest -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=80
+          pytest -v --tb=short --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false
       - name: Optional Reality Defender live smoke (non-blocking)
         continue-on-error: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1 with enforcement contact
+- `MAINTAINERS.md` — maintainer list and governance model
+- Codecov coverage reporting in CI and a coverage badge in the README
+- OpenSSF Scorecard badge in the README (workflow already publishes results)
+- Repository homepage link to the live demo
+
 - Global error handler with structured JSON error responses and request IDs
 - `docs/API.md` — comprehensive API reference with rate limits, error codes, and batch best practices; extended with previously undocumented endpoints: streaming text detection (SSE), detailed analysis, Stripe webhook, and full X-intelligence scheduler/drilldown/report; added `X-Billing-Webhook-Secret` to the request-headers table
 - `SECURITY.md` — responsible disclosure policy and security contact; refreshed for v1.x support matrix, GitHub private vulnerability advisories alongside email reporting, expanded in-scope surface (webhook signatures, SSE streaming, plan-quota logic, X-intel pipeline), production security controls section, and least-privilege contributor guidance

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+ogulcanaydogan@gmail.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,33 @@
+# Maintainers
+
+This file lists the maintainers of AI Provenance Tracker and explains how the
+project is governed.
+
+## Current maintainers
+
+| Maintainer | GitHub | Areas |
+|---|---|---|
+| Ogulcan Aydogan | [@ogulcanaydogan](https://github.com/ogulcanaydogan) | Detection engine, API, frontend, infrastructure, releases |
+
+## Governance
+
+The project currently operates under a single-maintainer model. The maintainer
+is responsible for reviewing and merging contributions, triaging issues, cutting
+releases, and upholding the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Decisions are made in the open through GitHub issues and pull requests. Larger
+proposals (new detection modalities, API contract changes, breaking changes)
+should start as an issue for discussion before implementation.
+
+## Becoming a maintainer
+
+Contributors who consistently submit high-quality pull requests, help with
+triage and review, and engage constructively with the community may be invited
+to become maintainers. If you are interested in a larger role, open an issue or
+reach out directly.
+
+## Contact
+
+- General and contribution questions: open a [GitHub issue](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/issues)
+- Security reports: see [SECURITY.md](SECURITY.md)
+- Code of Conduct concerns: ogulcanaydogan@gmail.com

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Built for fact-checking, newsroom workflows, trust-and-safety teams, and investi
 
 [![CI](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/actions/workflows/codeql.yml/badge.svg)](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/ogulcanaydogan/AI-Provenance-Tracker/branch/main/graph/badge.svg)](https://codecov.io/gh/ogulcanaydogan/AI-Provenance-Tracker)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ogulcanaydogan/AI-Provenance-Tracker/badge)](https://scorecard.dev/viewer/?uri=github.com/ogulcanaydogan/AI-Provenance-Tracker)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12171/badge)](https://www.bestpractices.dev/projects/12171)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12171/badge)](https://www.bestpractices.dev/projects/12171)
 
 [Live Demo](https://whoisfake.com) | [API Docs](https://api.whoisfake.com/docs) | [Benchmark & Status](docs/ROADMAP_STATUS.md) | [Open-Core Model](docs/OPEN_CORE.md)
 
@@ -125,14 +127,10 @@ curl -X POST "https://api.whoisfake.com/api/v1/detect/text" \
 - Roadmap and run evidence: [docs/ROADMAP_STATUS.md](docs/ROADMAP_STATUS.md)
 - Open-core boundary: [docs/OPEN_CORE.md](docs/OPEN_CORE.md)
 - Architecture details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-
-## Suggested GitHub About / Topics
-
-**About text (recommended):**
-Open-source multimodal AI provenance detection platform with explainable evidence cards, provider consensus, and benchmark-driven quality gates.
-
-**Topics (recommended):**
-`ai-detection`, `fact-checking`, `fastapi`, `nextjs`, `provenance`, `multimodal`
+- Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Maintainers and governance: [MAINTAINERS.md](MAINTAINERS.md)
+- Security policy: [SECURITY.md](SECURITY.md)
 
 ## Kisa TR Ozet
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [
-    { name = "Ogulcan Aydogan", email = "ogulcan@example.com" }
+    { name = "Ogulcan Aydogan", email = "ogulcanaydogan@gmail.com" }
 ]
 keywords = ["ai", "detection", "deepfake", "authenticity", "provenance"]
 classifiers = [
@@ -115,4 +115,4 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
-addopts = "-v --cov=app --cov-report=term-missing --cov-fail-under=80"
+addopts = "-v --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=80"


### PR DESCRIPTION
Closes the last presentation/credibility gaps so the repo reads as flagship-tier.

## What changed
- **Codecov**: emit `coverage.xml` in CI and upload via `codecov/codecov-action@v5` (non-blocking); coverage badge added to the README.
- **OpenSSF Scorecard badge** added to the README (the scorecard workflow already publishes results).
- **CODE_OF_CONDUCT.md** (Contributor Covenant 2.1) and **MAINTAINERS.md** (governance + contact).
- README: cross-linked community/governance/security docs in the documentation map; removed the leftover "suggested topics" note (topics are already configured on the repo).
- Fixed the placeholder package author email in `backend/pyproject.toml`.
- Repo homepage set to https://whoisfake.com (repo setting, outside the diff).

## Follow-up (not in this PR)
- **Demo screenshots**: automated capture of the live site timed out (animated hero hangs CDP screenshot). To be added to `docs/assets/` + embedded in the README separately.
- **Action required to light up the coverage badge**: connect the repo on codecov.io and add the `CODECOV_TOKEN` repository secret. Until then the upload step is a safe no-op.

No backend/detection code changed; engineering (tests, CI, security) was already mature.