### PR TITLE
ci: add PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,39 @@
+name: Publish to PyPI
+
+# Publishes the backend package to PyPI on every published GitHub Release using
+# OIDC Trusted Publishing (no API token stored as a secret). The Release is
+# created by release.yml when a v* tag is pushed, which fires the
+# `release: published` event below.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build sdist/wheel and publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade build
+          python -m build --outdir dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/dist


### PR DESCRIPTION
## What
Adds `.github/workflows/publish-pypi.yml` that builds the backend sdist/wheel and publishes `ai-provenance-tracker` to PyPI on every published GitHub Release.

## Why
The project ships GitHub Releases but is not installable via `pip`. Publishing to PyPI gives real, externally-verifiable install/usage metrics and a `pip install ai-provenance-tracker` entrypoint for adopters.

## How
- Trigger: `release: published` (chains off the existing `release.yml` v* tag flow) + manual `workflow_dispatch`.
- Uses **OIDC Trusted Publishing** (`pypa/gh-action-pypi-publish`) so no API token secret is stored.
- Build runs in `backend/` where `pyproject.toml` lives; verified locally from a clean `git archive` checkout (263KB sdist / 102KB wheel, no stray venv/cache files).

## Follow-up (one-time, manual)
PyPI side needs a pending publisher registered for this repo before the first release can publish: owner `ogulcanaydogan`, repo `AI-Provenance-Tracker`, workflow `publish-pypi.yml`, environment `pypi`.