### PR TITLE
chore: bump version to 1.0.1 for first PyPI release

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ai-provenance-tracker"
-version = "0.1.0"
+version = "1.0.1"
 description = "Detect AI-generated content, trace origins, verify authenticity"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Aligns the package version with the project's GitHub release history (latest tag v1.0.0) ahead of the first PyPI publish via the trusted-publishing workflow. Releasing v1.0.1 will publish `ai-provenance-tracker==1.0.1` to PyPI.