### PR TITLE
docs: add PyPI badge and pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Built for fact-checking, newsroom workflows, trust-and-safety teams, and investi
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12171/badge)](https://www.bestpractices.dev/projects/12171)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/ai-provenance-tracker.svg)](https://pypi.org/project/ai-provenance-tracker/)
 [![Container image](https://img.shields.io/badge/ghcr.io-provenance--api-2496ED?logo=docker&logoColor=white)](https://github.com/ogulcanaydogan/AI-Provenance-Tracker/pkgs/container/provenance-api)
 
 [Live Demo](https://whoisfake.com) | [API Docs](https://api.whoisfake.com/docs) | [Benchmark & Status](docs/ROADMAP_STATUS.md) | [Open-Core Model](docs/OPEN_CORE.md)
@@ -104,6 +105,14 @@ make up
 - API: `http://localhost:8000`
 - Swagger: `http://localhost:8000/docs`
 - URL analysis UI: `http://localhost:3000/detect/url`
+
+### Install from PyPI
+
+The backend package is published to PyPI:
+
+```bash
+pip install ai-provenance-tracker
+```
 
 ### Prebuilt API image
 


### PR DESCRIPTION
Now that `ai-provenance-tracker` is published to PyPI (1.0.1), adds the PyPI version badge and a `pip install ai-provenance-tracker` section to the README. Doc-only.