### PR TITLE
feat: add provenance command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ The backend package is published to PyPI:
 pip install ai-provenance-tracker
 ```
 
+### Command-line interface
+
+Installing the package adds a `provenance` command so you can run detection from
+the terminal without starting the API server (no database, no network except
+`--url`):
+
+```bash
+provenance detect --text "some text to analyze"
+echo "piped text" | provenance detect --text -
+provenance detect --file path/to/image.png
+provenance detect --url https://example.com/article
+provenance detect --text "..." --json           # machine-readable output
+provenance detect --file clip.wav --fail-on-ai   # exit 1 if AI-generated
+```
+
+The file modality is inferred from the extension (image, audio WAV, video, or
+text). Text detection runs on pure heuristics unless the optional `[ml]` extra
+is installed, so the CLI stays fully offline by default.
+
 ### Prebuilt API image
 
 The backend API is published to GHCR, so you can run it without building:

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,229 @@
+"""Command-line interface for AI Provenance Tracker.
+
+Run content detection from the terminal without starting the API server. The
+CLI calls the bare modality detectors directly, so it has no database, no
+network (except ``--url``), and no provider-consensus side effects.
+
+Examples
+--------
+    provenance detect --text "some text to analyze"
+    echo "piped text" | provenance detect --text -
+    provenance detect --file path/to/image.png
+    provenance detect --url https://example.com/article
+    provenance detect --text "..." --json          # machine-readable output
+    provenance detect --file clip.wav --fail-on-ai  # exit 1 if AI-generated
+
+Text detection runs on pure heuristics when the optional ``[ml]`` extra
+(transformers + torch) is not installed, which keeps the CLI fully offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif", ".tiff"}
+AUDIO_EXTENSIONS = {".wav"}
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"}
+
+
+def _modality_for_path(path: Path) -> str:
+    """Infer the detection modality from a file extension (text by default)."""
+    suffix = path.suffix.lower()
+    if suffix in IMAGE_EXTENSIONS:
+        return "image"
+    if suffix in AUDIO_EXTENSIONS:
+        return "audio"
+    if suffix in VIDEO_EXTENSIONS:
+        return "video"
+    return "text"
+
+
+def _modality_for_content_type(content_type: str) -> str:
+    """Map an HTTP content-type to a detection modality."""
+    main = content_type.split(";", 1)[0].strip().lower()
+    if main.startswith("image/"):
+        return "image"
+    if main.startswith("audio/"):
+        return "audio"
+    if main.startswith("video/"):
+        return "video"
+    return "text"
+
+
+def _strip_html(raw: str) -> str:
+    """Best-effort plain-text extraction from an HTML document."""
+    import re
+
+    without_scripts = re.sub(
+        r"<(script|style)[^>]*>.*?</\1>", " ", raw, flags=re.DOTALL | re.IGNORECASE
+    )
+    text = re.sub(r"<[^>]+>", " ", without_scripts)
+    text = re.sub(r"&[a-zA-Z#0-9]+;", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+async def _detect_text(text: str, domain: Optional[str]) -> dict[str, Any]:
+    from app.detection import TextDetector
+
+    result = await TextDetector().detect(text, domain=domain)
+    return result.model_dump(mode="json")
+
+
+async def _detect_bytes(modality: str, data: bytes, filename: str) -> dict[str, Any]:
+    from app.detection import AudioDetector, ImageDetector, VideoDetector
+
+    detectors = {
+        "image": ImageDetector,
+        "audio": AudioDetector,
+        "video": VideoDetector,
+    }
+    detector = detectors[modality]()
+    result = await detector.detect(data, filename)
+    return result.model_dump(mode="json")
+
+
+def _fetch_url(url: str) -> tuple[str, bytes, str]:
+    """Fetch a URL, returning (modality, body bytes, filename)."""
+    import httpx
+
+    with httpx.Client(follow_redirects=True, timeout=30.0) as client:
+        response = client.get(url)
+        response.raise_for_status()
+    content_type = response.headers.get("content-type", "text/plain")
+    modality = _modality_for_content_type(content_type)
+    filename = Path(url.split("?", 1)[0]).name or "download"
+    return modality, response.content, filename
+
+
+def _verdict(data: dict[str, Any]) -> tuple[str, bool]:
+    """Return a human verdict label and whether it is an AI-generated call."""
+    band = data.get("decision_band")
+    is_ai = bool(data.get("is_ai_generated"))
+    if band == "ai" or (band is None and is_ai):
+        return "AI-generated", True
+    if band == "human" or (band is None and not is_ai):
+        return "Human-written", False
+    return "Uncertain", False
+
+
+def _print_pretty(modality: str, data: dict[str, Any]) -> None:
+    label, _ = _verdict(data)
+    confidence = float(data.get("confidence", 0.0)) * 100.0
+    print(f"AI Provenance Tracker - {modality}")
+    print(f"Verdict: {label} (confidence {confidence:.1f}%)")
+    reason = data.get("uncertainty_reason")
+    if reason:
+        print(f"Reason: {reason}")
+    explanation = data.get("explanation")
+    if explanation:
+        print(f"\n{explanation}")
+    analysis = data.get("analysis") or {}
+    if isinstance(analysis, dict) and analysis:
+        print("\nAnalysis:")
+        for key, value in analysis.items():
+            print(f"  {key}: {value}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="provenance",
+        description="Detect AI-generated content from the terminal.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    detect = subparsers.add_parser(
+        "detect", help="Run detection on text, a file, or a URL."
+    )
+    source = detect.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--text", metavar="TEXT", help='Text to analyze (use "-" to read stdin).'
+    )
+    source.add_argument(
+        "--file", metavar="PATH", help="Path to an image, audio, video, or text file."
+    )
+    source.add_argument(
+        "--url", metavar="URL", help="URL to fetch and analyze (requires network)."
+    )
+    detect.add_argument("--domain", help="Optional domain hint for text detection.")
+    detect.add_argument(
+        "--json", action="store_true", help="Emit the raw result as JSON."
+    )
+    detect.add_argument(
+        "--fail-on-ai",
+        action="store_true",
+        help="Exit with status 1 when the verdict is AI-generated.",
+    )
+    return parser
+
+
+def _resolve_input(args: argparse.Namespace) -> tuple[str, dict[str, Any]]:
+    """Resolve CLI args to (modality, result dict)."""
+    if args.text is not None:
+        text = sys.stdin.read() if args.text == "-" else args.text
+        if not text.strip():
+            raise ValueError("no text provided")
+        return "text", asyncio.run(_detect_text(text, args.domain))
+
+    if args.file is not None:
+        path = Path(args.file)
+        if not path.is_file():
+            raise FileNotFoundError(f"file not found: {path}")
+        modality = _modality_for_path(path)
+        if modality == "text":
+            text = path.read_text(encoding="utf-8", errors="replace")
+            if not text.strip():
+                raise ValueError("file is empty")
+            return "text", asyncio.run(_detect_text(text, args.domain))
+        return modality, asyncio.run(
+            _detect_bytes(modality, path.read_bytes(), path.name)
+        )
+
+    # args.url
+    modality, body, filename = _fetch_url(args.url)
+    if modality == "text":
+        text = _strip_html(body.decode("utf-8", errors="replace"))
+        if not text.strip():
+            raise ValueError("no extractable text at URL")
+        return "text", asyncio.run(_detect_text(text, args.domain))
+    return modality, asyncio.run(_detect_bytes(modality, body, filename))
+
+
+def run(argv: Optional[list[str]] = None) -> int:
+    """Entry point usable from tests; returns a process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        modality, data = _resolve_input(args)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - surface any detector/network error cleanly
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        _print_pretty(modality, data)
+
+    _, is_ai = _verdict(data)
+    if args.fail_on_ai and is_ai:
+        return 1
+    return 0
+
+
+def main() -> None:
+    """Console-script entry point."""
+    raise SystemExit(run(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -136,23 +136,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    detect = subparsers.add_parser(
-        "detect", help="Run detection on text, a file, or a URL."
-    )
+    detect = subparsers.add_parser("detect", help="Run detection on text, a file, or a URL.")
     source = detect.add_mutually_exclusive_group(required=True)
-    source.add_argument(
-        "--text", metavar="TEXT", help='Text to analyze (use "-" to read stdin).'
-    )
+    source.add_argument("--text", metavar="TEXT", help='Text to analyze (use "-" to read stdin).')
     source.add_argument(
         "--file", metavar="PATH", help="Path to an image, audio, video, or text file."
     )
-    source.add_argument(
-        "--url", metavar="URL", help="URL to fetch and analyze (requires network)."
-    )
+    source.add_argument("--url", metavar="URL", help="URL to fetch and analyze (requires network).")
     detect.add_argument("--domain", help="Optional domain hint for text detection.")
-    detect.add_argument(
-        "--json", action="store_true", help="Emit the raw result as JSON."
-    )
+    detect.add_argument("--json", action="store_true", help="Emit the raw result as JSON.")
     detect.add_argument(
         "--fail-on-ai",
         action="store_true",
@@ -179,9 +171,7 @@ def _resolve_input(args: argparse.Namespace) -> tuple[str, dict[str, Any]]:
             if not text.strip():
                 raise ValueError("file is empty")
             return "text", asyncio.run(_detect_text(text, args.domain))
-        return modality, asyncio.run(
-            _detect_bytes(modality, path.read_bytes(), path.name)
-        )
+        return modality, asyncio.run(_detect_bytes(modality, path.read_bytes(), path.name))
 
     # args.url
     modality, body, filename = _fetch_url(args.url)
@@ -203,9 +193,7 @@ def run(argv: Optional[list[str]] = None) -> int:
     except (ValueError, FileNotFoundError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 - surface any detector/network error cleanly
+    except Exception as exc:  # noqa: BLE001 - surface any detector/network error cleanly
         print(f"error: {exc}", file=sys.stderr)
         return 2
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -64,6 +64,9 @@ dev = [
     "pre-commit>=3.6.0",
 ]
 
+[project.scripts]
+provenance = "app.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/ogulcanaydogan/ai-provenance-tracker"
 Documentation = "https://github.com/ogulcanaydogan/ai-provenance-tracker#readme"

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,146 @@
+"""Tests for the `provenance` command-line interface (app.cli).
+
+These run fully offline: text detection uses the heuristic path (no [ml] extra
+installed in CI) and audio uses an in-memory synthetic WAV. Exit-code logic is
+exercised deterministically by stubbing the detector call.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import struct
+import wave
+
+import pytest
+
+from app import cli
+
+# --- pure helpers (deterministic) -------------------------------------------
+
+
+def test_modality_for_path_by_extension(tmp_path):
+    assert cli._modality_for_path(tmp_path / "a.PNG") == "image"
+    assert cli._modality_for_path(tmp_path / "a.wav") == "audio"
+    assert cli._modality_for_path(tmp_path / "a.mp4") == "video"
+    assert cli._modality_for_path(tmp_path / "a.txt") == "text"
+    assert cli._modality_for_path(tmp_path / "noext") == "text"
+
+
+def test_modality_for_content_type():
+    assert cli._modality_for_content_type("image/png") == "image"
+    assert cli._modality_for_content_type("audio/wav") == "audio"
+    assert cli._modality_for_content_type("video/mp4; codecs=x") == "video"
+    assert cli._modality_for_content_type("text/html; charset=utf-8") == "text"
+    assert cli._modality_for_content_type("application/json") == "text"
+
+
+def test_strip_html_removes_tags_and_scripts():
+    html = "<html><head><style>x{}</style></head><body><p>Hello</p><script>1</script>world</body></html>"
+    assert cli._strip_html(html) == "Hello world"
+
+
+@pytest.mark.parametrize(
+    "data,label,is_ai",
+    [
+        ({"decision_band": "ai", "is_ai_generated": True}, "AI-generated", True),
+        ({"decision_band": "human", "is_ai_generated": False}, "Human-written", False),
+        ({"decision_band": "uncertain", "is_ai_generated": True}, "Uncertain", False),
+        (
+            {"is_ai_generated": True},
+            "AI-generated",
+            True,
+        ),  # no band (image/audio/video)
+        ({"is_ai_generated": False}, "Human-written", False),
+    ],
+)
+def test_verdict(data, label, is_ai):
+    assert cli._verdict(data) == (label, is_ai)
+
+
+# --- integration through run() ----------------------------------------------
+
+
+def test_detect_text_pretty(capsys):
+    code = cli.run(["detect", "--text", "The quick brown fox jumps over the lazy dog."])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "AI Provenance Tracker - text" in out
+    assert "Verdict:" in out
+    assert "Analysis:" in out
+
+
+def test_detect_text_json_is_machine_readable(capsys):
+    code = cli.run(["detect", "--text", "Some sample sentence for analysis.", "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    payload = json.loads(out)
+    assert "is_ai_generated" in payload
+    assert "confidence" in payload
+    assert "analysis" in payload
+
+
+def test_detect_text_from_stdin(capsys, monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("piped in text for detection"))
+    code = cli.run(["detect", "--text", "-", "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "confidence" in json.loads(out)
+
+
+def test_empty_text_returns_error(capsys):
+    code = cli.run(["detect", "--text", "   "])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "error:" in err
+
+
+def test_missing_file_returns_error(capsys, tmp_path):
+    code = cli.run(["detect", "--file", str(tmp_path / "nope.png")])
+    assert code == 2
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_detect_audio_file(capsys, tmp_path):
+    wav_path = tmp_path / "clip.wav"
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(16000)
+        frames = b"".join(struct.pack("<h", (i % 100) - 50) for i in range(16000))
+        handle.writeframes(frames)
+    wav_path.write_bytes(buffer.getvalue())
+
+    code = cli.run(["detect", "--file", str(wav_path), "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "confidence" in json.loads(out)
+
+
+def test_fail_on_ai_exit_code(capsys, monkeypatch):
+    async def fake_ai(text, domain):
+        return {
+            "decision_band": "ai",
+            "is_ai_generated": True,
+            "confidence": 0.9,
+            "analysis": {},
+        }
+
+    monkeypatch.setattr(cli, "_detect_text", fake_ai)
+    assert cli.run(["detect", "--text", "x", "--fail-on-ai"]) == 1
+    # without the flag, an AI verdict still exits 0
+    assert cli.run(["detect", "--text", "x"]) == 0
+
+
+def test_fail_on_ai_passes_for_human(capsys, monkeypatch):
+    async def fake_human(text, domain):
+        return {
+            "decision_band": "human",
+            "is_ai_generated": False,
+            "confidence": 0.1,
+            "analysis": {},
+        }
+
+    monkeypatch.setattr(cli, "_detect_text", fake_human)
+    assert cli.run(["detect", "--text", "x", "--fail-on-ai"]) == 0


### PR DESCRIPTION
## What
Adds a `provenance` console command so `pip install ai-provenance-tracker` users can run detection from the terminal, mirroring the web evidence card.

```bash
provenance detect --text "some text"
echo "piped" | provenance detect --text -
provenance detect --file image.png        # modality inferred from extension
provenance detect --url https://example.com/article
provenance detect --text "..." --json     # machine-readable
provenance detect --file clip.wav --fail-on-ai   # exit 1 if AI-generated
```

## Why
The package shipped to PyPI as a FastAPI backend with no standalone entry point, so an installed user could not actually *use* it without running the server. A CLI makes the published package usable in one command and scriptable in pipelines (`--json`, `--fail-on-ai` exit codes).

## How
- New `backend/app/cli.py` calls the bare modality detectors (`TextDetector`/`ImageDetector`/`AudioDetector`/`VideoDetector`) directly and serializes the Pydantic result via `model_dump`. It deliberately skips the API's consensus/store/audit layers, so it has no DB and no network (except `--url`).
- Text runs on heuristics when the optional `[ml]` extra is absent, keeping the CLI offline by default.
- Registers `[project.scripts] provenance = "app.cli:main"`.
- `backend/tests/test_cli.py`: 16 tests (modality inference, HTML strip, verdict mapping, text/stdin/file/audio detection, JSON output, error exit codes, `--fail-on-ai`), all offline.

## Verification
Full backend suite: **381 passed, coverage 84%** (gate is 80%). ruff + black clean. Verified the installed `provenance` command end to end against the heuristic text path and a synthetic WAV.