### PR TITLE
chore: bump version to 1.1.0 for the provenance CLI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ai-provenance-tracker"
-version = "1.0.1"
+version = "1.1.0"
 description = "Detect AI-generated content, trace origins, verify authenticity"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Releases the new `provenance` command-line interface (PR #113) to PyPI. Cutting v1.1.0 publishes `ai-provenance-tracker==1.1.0`, so `pip install ai-provenance-tracker` provides the `provenance` command.