### PR TITLE
fix: drop build toolchain from runtime image to clear CVE gate

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,15 +2,21 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-# Apply OS security patches then install build deps.
+# Apply OS security patches then install runtime + build deps.
+# curl is a runtime dependency (healthcheck); build-essential is only needed to
+# compile any Python packages without wheels and is purged again below so that
+# build-only packages (gcc, linux-libc-dev, ...) do not ship in the runtime image.
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends build-essential curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy and install Python dependencies first (better caching)
+# Copy and install Python dependencies first (better caching), then drop the
+# build toolchain so the runtime image has a smaller CVE/attack surface.
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## What
Purges `build-essential` (and its auto-removed transitive packages) from the backend runtime image after `pip install`, so build-only packages like `gcc` and `linux-libc-dev` no longer ship in the published `provenance-api`/`provenance-worker` images.

## Why
The scheduled **Verify Production Images** gate went red: the published images carried `linux-libc-dev 6.1.174-1` with fixable critical **CVE-2026-53215** (fixed in 6.1.176-1). That version is not yet in the Debian bookworm apt mirror (`apt-cache policy` candidate is still 6.1.174-1), so a plain rebuild can't patch it. But `linux-libc-dev` is a **build-time-only** transitive dependency of `build-essential` — it has no business being in the runtime image. Removing the build toolchain eliminates the CVE and shrinks the attack surface.

## How
- Keep `build-essential` during `pip install` (in case any dependency needs to compile), then `apt-get purge -y --auto-remove build-essential` in the same layer.
- `curl` (runtime healthcheck dep) is kept; `libgcc-s1` (runtime GCC support lib used by compiled wheels) is correctly retained.

## Verification (local build)
- Built the image locally; `trivy image --ignore-unfixed --severity CRITICAL` → **0 fixable criticals** (was 1 per image: linux-libc-dev).
- `dpkg -l` confirms `build-essential`/`gcc-12`/`linux-libc-dev` removed; `libgcc-s1` retained.
- `docker run ... python -c 'import app.main'` → **import OK** (app still starts after the purge).

Merging republishes the images (publish-images.yml runs on backend/** push), which clears the Verify Production Images gate.