### PR TITLE
feat: add shareable evidence report page

### DIFF
--- a/frontend/src/__tests__/detection-components.test.tsx
+++ b/frontend/src/__tests__/detection-components.test.tsx
@@ -103,10 +103,10 @@ describe("ResultCard", () => {
     expect(screen.getByText("Copy Shareable Evidence")).toBeDefined();
   });
 
-  it("renders evidence json link", () => {
+  it("renders evidence report link", () => {
     render(<ResultCard result={result} />);
-    const link = screen.getByRole("link", { name: "Open Evidence JSON" });
-    expect(link.getAttribute("href")).toContain("/api/v1/analyze/evidence/test-1");
+    const link = screen.getByRole("link", { name: "Open Evidence Report" });
+    expect(link.getAttribute("href")).toBe("/evidence/test-1");
   });
 });
 

--- a/frontend/src/app/evidence/[id]/page.tsx
+++ b/frontend/src/app/evidence/[id]/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { getEvidencePack, getEvidencePackUrl } from "@/lib/api";
+import { BackendEvidencePack } from "@/lib/types";
+import { VERDICT_LABELS, VERDICT_BG_COLORS } from "@/lib/constants";
+import { formatDate, formatConfidence } from "@/lib/utils";
+import { ConfidenceGauge } from "@/components/detection/ConfidenceGauge";
+import { AlertCircle, Clock, Code2, Copy, Check } from "lucide-react";
+
+const DECISION_BAND_LABELS: Record<string, string> = {
+  human: "Human",
+  uncertain: "Uncertain",
+  ai: "AI",
+};
+
+interface LoadedEvidence {
+  id: string;
+  pack: BackendEvidencePack | null;
+  error: string | null;
+}
+
+function toPercent(value: number): number {
+  return Number((Math.max(0, Math.min(value, 1)) * 100).toFixed(1));
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-gray-500">{label}</dt>
+      <dd className="text-sm text-gray-200 mt-1 break-words">{value}</dd>
+    </div>
+  );
+}
+
+function ChunkTable({ pack }: { pack: BackendEvidencePack }) {
+  const summary = pack.trace.chunk_summary;
+  if (!summary) return null;
+
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+        Chunk Consistency
+      </h2>
+      <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+        <Field label="Chunks" value={String(summary.chunk_count)} />
+        <Field label="Mean confidence" value={formatConfidence(toPercent(summary.mean_confidence))} />
+        <Field label="Spread" value={formatConfidence(toPercent(summary.confidence_spread))} />
+        <Field label="Disagreement" value={formatConfidence(toPercent(summary.disagreement_ratio))} />
+      </dl>
+      <p className="text-sm text-gray-400 mb-4">
+        Chunks were routed mostly as <span className="text-gray-200">{summary.dominant_domain}</span>
+        {summary.route_mismatch
+          ? ", which disagrees with the case-level route."
+          : ", matching the case-level route."}
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wider text-gray-500 border-b border-gray-800">
+              <th className="py-2 pr-4 font-medium">Chunk</th>
+              <th className="py-2 pr-4 font-medium">Words</th>
+              <th className="py-2 pr-4 font-medium">Sentences</th>
+              <th className="py-2 pr-4 font-medium">AI confidence</th>
+              <th className="py-2 pr-4 font-medium">Band</th>
+              <th className="py-2 font-medium">Route</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summary.chunks.map((chunk) => (
+              <tr key={chunk.index} className="border-b border-gray-800/60">
+                <td className="py-2 pr-4 text-gray-400">{chunk.index + 1}</td>
+                <td className="py-2 pr-4 text-gray-300">{chunk.word_count}</td>
+                <td className="py-2 pr-4 text-gray-300">{chunk.sentence_count}</td>
+                <td className="py-2 pr-4 text-gray-200">
+                  {formatConfidence(toPercent(chunk.confidence))}
+                </td>
+                <td className="py-2 pr-4 text-gray-300">
+                  {DECISION_BAND_LABELS[chunk.decision_band] || chunk.decision_band}
+                </td>
+                <td className="py-2 text-gray-400">{chunk.domain_profile}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default function EvidencePage() {
+  const params = useParams<{ id: string }>();
+  const analysisId = params.id;
+  const [loaded, setLoaded] = useState<LoadedEvidence | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    getEvidencePack(analysisId)
+      .then((pack) => {
+        if (active) setLoaded({ id: analysisId, pack, error: null });
+      })
+      .catch((err: Error) => {
+        if (active) setLoaded({ id: analysisId, pack: null, error: err.message });
+      });
+    return () => {
+      active = false;
+    };
+  }, [analysisId]);
+
+  // Anything loaded for a previous id is stale while the new one is in flight.
+  const loading = loaded?.id !== analysisId;
+  const pack = loaded?.pack ?? null;
+  const error = loaded?.error ?? null;
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2500);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="h-8 w-64 rounded-lg bg-gray-800 animate-pulse" />
+        <div
+          className="h-72 rounded-2xl bg-gray-800 animate-pulse mt-8"
+          role="status"
+          aria-label="Loading evidence report"
+        />
+      </main>
+    );
+  }
+
+  if (error || !pack) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div
+          role="alert"
+          className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-center gap-3"
+        >
+          <AlertCircle className="h-5 w-5 text-red-400 flex-shrink-0" aria-hidden="true" />
+          <p className="text-sm text-red-300">{error || "Evidence report not found."}</p>
+        </div>
+        <Link
+          href="/detect/text"
+          className="inline-block mt-6 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          Run a new analysis
+        </Link>
+      </main>
+    );
+  }
+
+  const confidencePercent = toPercent(pack.confidence);
+  const { trace, detector_versions: versions } = pack;
+  const lineage = trace.artifact_lineage;
+
+  return (
+    <main
+      className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+      aria-labelledby="evidence-heading"
+    >
+      <div className="mb-8">
+        <h1 id="evidence-heading" className="text-3xl font-bold text-white">
+          Evidence Report
+        </h1>
+        <p className="text-gray-400 mt-2">
+          A shareable record of how whoisfake.com reached this verdict.
+        </p>
+      </div>
+
+      <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 space-y-8">
+        <div className="flex items-center justify-between">
+          <span
+            className={`px-3 py-1 rounded-full text-sm font-medium border ${
+              VERDICT_BG_COLORS[pack.verdict] || ""
+            }`}
+          >
+            {VERDICT_LABELS[pack.verdict] || pack.verdict}
+          </span>
+          <div className="flex items-center gap-1.5 text-xs text-gray-500">
+            <Clock className="h-3.5 w-3.5" />
+            {formatDate(pack.timestamp)}
+          </div>
+        </div>
+
+        <div className="flex justify-center py-2">
+          <ConfidenceGauge score={confidencePercent} verdict={pack.verdict} />
+        </div>
+
+        {pack.explanation && (
+          <div className="bg-gray-800/30 rounded-xl p-4">
+            <p className="text-sm text-gray-300 leading-relaxed">{pack.explanation}</p>
+          </div>
+        )}
+
+        {pack.uncertainty_reason && (
+          <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4">
+            <p className="text-sm text-yellow-200">{pack.uncertainty_reason}</p>
+          </div>
+        )}
+
+        <section>
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+            Analysis
+          </h2>
+          <dl className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            <Field label="Analysis ID" value={pack.analysis_id} />
+            <Field label="Content type" value={pack.content_type} />
+            <Field
+              label="Decision band"
+              value={
+                pack.decision_band
+                  ? DECISION_BAND_LABELS[pack.decision_band] || pack.decision_band
+                  : "—"
+              }
+            />
+            <Field label="Source" value={pack.source} />
+            <Field label="Source URL" value={pack.source_url || "—"} />
+            <Field label="Route profile" value={trace.route_profile || "—"} />
+          </dl>
+        </section>
+
+        {(trace.uncertainty_flags.length > 0 || trace.disagreement_reasons.length > 0) && (
+          <section>
+            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+              Guardrails
+            </h2>
+            <ul className="space-y-2">
+              {[...trace.uncertainty_flags, ...trace.disagreement_reasons].map((item) => (
+                <li key={item} className="text-sm text-gray-300">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <ChunkTable pack={pack} />
+
+        <section>
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+            Detector Versions
+          </h2>
+          <dl className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            <Field label="Model" value={versions.model_version || "—"} />
+            <Field label="Calibration" value={versions.calibration_version || "—"} />
+            <Field label="Model bundle" value={lineage.model_bundle_version || "—"} />
+            <Field label="Calibration bundle" value={lineage.calibration_bundle_version || "—"} />
+            <Field label="Benchmark manifest" value={lineage.private_benchmark_manifest || "—"} />
+          </dl>
+        </section>
+
+        <div className="flex flex-wrap justify-end gap-2 border-t border-gray-800 pt-6">
+          <a
+            href={getEvidencePackUrl(pack.analysis_id)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#333] text-gray-200 hover:text-white hover:border-[#4a4a4a] transition-colors text-xs"
+          >
+            <Code2 className="h-3.5 w-3.5" />
+            View raw JSON
+          </a>
+          <button
+            type="button"
+            onClick={copyLink}
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#333] text-gray-200 hover:text-white hover:border-[#4a4a4a] transition-colors text-xs"
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Link copied" : "Copy link"}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/detection/ResultCard.tsx
+++ b/frontend/src/components/detection/ResultCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { DetectionResult } from "@/lib/types";
 import { formatDate } from "@/lib/utils";
 import { VERDICT_LABELS, VERDICT_BG_COLORS } from "@/lib/constants";
@@ -14,11 +15,7 @@ interface ResultCardProps {
 
 export function ResultCard({ result }: ResultCardProps) {
   const [copied, setCopied] = useState(false);
-  const apiBase = (process.env.NEXT_PUBLIC_API_URL?.trim() || "https://api.whoisfake.com").replace(
-    /\/+$/,
-    ""
-  );
-  const evidenceUrl = `${apiBase}/api/v1/analyze/evidence/${result.id}`;
+  const evidencePath = `/evidence/${result.id}`;
 
   async function copyEvidenceSummary() {
     const summary = [
@@ -27,7 +24,7 @@ export function ResultCard({ result }: ResultCardProps) {
       `timestamp: ${result.analyzed_at}`,
       `analysis_id: ${result.id}`,
       `content_type: ${result.content_type}`,
-      `evidence_url: ${evidenceUrl}`,
+      `evidence_url: ${window.location.origin}${evidencePath}`,
     ].join("\n");
 
     try {
@@ -67,15 +64,13 @@ export function ResultCard({ result }: ResultCardProps) {
       </div>
 
       <div className="flex flex-wrap justify-end gap-2">
-        <a
-          href={evidenceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          href={evidencePath}
           className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#333] text-gray-200 hover:text-white hover:border-[#4a4a4a] transition-colors text-xs"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          Open Evidence JSON
-        </a>
+          Open Evidence Report
+        </Link>
         <button
           type="button"
           onClick={copyEvidenceSummary}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,7 @@ import {
   BackendDetailedAnalysisResponse,
   BackendDetectionResponse,
   BackendEvaluationResponse,
+  BackendEvidencePack,
   BackendHistoryItem,
   BackendHistoryResponse,
   BackendUrlDetectionResponse,
@@ -577,6 +578,15 @@ export async function getAnalysis(id: string): Promise<DetectionResult> {
     payload.details.content_type,
     payload.metadata?.created_at
   );
+}
+
+export function getEvidencePackUrl(id: string): string {
+  return `${API_URL}/api/v1/analyze/evidence/${encodeURIComponent(id)}`;
+}
+
+export async function getEvidencePack(id: string): Promise<BackendEvidencePack> {
+  const response = await request(getEvidencePackUrl(id));
+  return handleResponse<BackendEvidencePack>(response);
 }
 
 export async function getDashboard(days = 14): Promise<BackendDashboardResponse> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -7,6 +7,8 @@ export type Verdict =
   | "likely_ai"
   | "ai_generated";
 
+export type DecisionBand = "human" | "uncertain" | "ai";
+
 export interface DetectionSignal {
   name: string;
   score: number; // 0-1
@@ -92,7 +94,7 @@ export interface BackendTextDetectionResponse {
   analysis_id?: string | null;
   is_ai_generated: boolean;
   confidence: number; // 0-1
-  decision_band: "human" | "uncertain" | "ai";
+  decision_band: DecisionBand;
   distance_to_threshold: number;
   uncertainty_reason?: string | null;
   model_prediction: string | null;
@@ -194,6 +196,55 @@ export interface BackendDetailedAnalysisResponse {
   };
   metadata?: {
     created_at?: string;
+  };
+}
+
+export interface BackendEvidenceChunk {
+  index: number;
+  word_count: number;
+  sentence_count: number;
+  confidence: number; // 0-1
+  decision_band: DecisionBand;
+  distance_to_threshold: number;
+  domain_profile: string;
+}
+
+export interface BackendEvidenceChunkSummary {
+  chunk_count: number;
+  aggregate_confidence: number;
+  mean_confidence: number;
+  confidence_spread: number;
+  disagreement_ratio: number;
+  dominant_domain: string;
+  route_mismatch: boolean;
+  chunks: BackendEvidenceChunk[];
+}
+
+export interface BackendEvidencePack {
+  analysis_id: string;
+  content_type: ContentType;
+  verdict: Verdict;
+  confidence: number; // 0-1
+  decision_band: DecisionBand | null;
+  uncertainty_reason: string | null;
+  timestamp: string;
+  source: string;
+  source_url: string | null;
+  explanation: string | null;
+  detector_versions: {
+    model_version: string | null;
+    calibration_version: string | null;
+  };
+  trace: {
+    route_profile: string | null;
+    uncertainty_flags: string[];
+    chunk_summary: BackendEvidenceChunkSummary | null;
+    disagreement_reasons: string[];
+    artifact_lineage: {
+      model_bundle_version: string | null;
+      calibration_bundle_version: string | null;
+      private_benchmark_manifest: string | null;
+    };
   };
 }
 


### PR DESCRIPTION
## Problem

The "Copy Shareable Evidence" / evidence link in `ResultCard` pointed straight at the JSON API endpoint (`api.whoisfake.com/api/v1/analyze/evidence/{id}`). Opening a shared link showed a raw payload — fine for a script, useless for the person you sent it to.

## Change

- New `/evidence/[id]` page rendering the same evidence pack as a readable report: verdict badge, confidence gauge, explanation, uncertainty reason, analysis metadata, guardrail flags, chunk-consistency table, and detector/artifact versions.
- `ResultCard` now links to that page, and the copied summary's `evidence_url` points there too.
- `getEvidencePack` / `getEvidencePackUrl` + evidence pack types added to the frontend API client.

The JSON endpoint is untouched and remains the machine-readable contract; the page links out to it via "View raw JSON".

## Notes

- Previously shared `api.whoisfake.com/...` links keep returning JSON — only newly copied links use the page.
- The page fetches client-side, matching the existing `history` page pattern. That means no link-preview/OG metadata for shared links; worth revisiting with a server component + `generateMetadata` if that matters for a "shareable" surface.

## Verification

Ran the dev server against the production API and loaded a real analysis id: every field in the raw JSON renders correctly (chunk confidences 0.209/0.007/0.016/0.049/0.013/0.141 → 20.9%/0.7%/1.6%/4.9%/1.3%/14.1%). An unknown id shows "Analysis not found"; no console errors. Tests (169), lint, and typecheck pass.